### PR TITLE
pfifo_fast: fix priomap reportin

### DIFF
--- a/pyroute2/netlink/generic.py
+++ b/pyroute2/netlink/generic.py
@@ -352,7 +352,10 @@ class nlmsg_base(dict):
                         if field[1] == 'z' and self[name][-1] in (0x00, '\0'):
                             self[name] = self[name][:-1]
                     else:
-                        self.update(dict(zip(name.split(","), value)))
+                        if ',' in name:
+                            self.update(dict(zip(name.split(","), value)))
+                        else:
+                            self[name] = value
 
                 else:
                     # FIXME: log an error

--- a/pyroute2/netlink/rtnl/tcmsg.py
+++ b/pyroute2/netlink/rtnl/tcmsg.py
@@ -824,22 +824,7 @@ class tcmsg(nlmsg, nla_plus_stats2):
 
     class options_pfifo_fast(nla):
         fields = (('bands', 'i'),
-                  ('mark_01', 'B'),
-                  ('mark_02', 'B'),
-                  ('mark_03', 'B'),
-                  ('mark_04', 'B'),
-                  ('mark_05', 'B'),
-                  ('mark_06', 'B'),
-                  ('mark_07', 'B'),
-                  ('mark_08', 'B'),
-                  ('mark_09', 'B'),
-                  ('mark_10', 'B'),
-                  ('mark_11', 'B'),
-                  ('mark_12', 'B'),
-                  ('mark_13', 'B'),
-                  ('mark_14', 'B'),
-                  ('mark_15', 'B'),
-                  ('mark_16', 'B'))
+                  ('priomap', '16B'))
 
     class options_tbf(nla_plus_rtab):
         nla_map = (('TCA_TBF_UNSPEC', 'none'),


### PR DESCRIPTION
Priomap was incorrectly (inconsistent with the kernel) as separate
fields:

('TCA_OPTIONS',
    {'bands': 3,
     'mark_01': 1,
     'mark_02': 2,
     'mark_03': 2,
     'mark_04': 2,
     'mark_05': 1,
     'mark_06': 2,
     'mark_07': 0,
     'mark_08': 0,
     'mark_09': 1,
     'mark_10': 1,
     'mark_11': 1,
     'mark_12': 1,
     'mark_13': 1,
     'mark_14': 1,
     'mark_15': 1,
     'mark_16': 1}),

When it should have been:
    ['TCA_OPTIONS',
        {'bands': 3,
         'priomap': (1, 2, 2, 2, 1, 2, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1)}],

Signed-off-by: Antoni S. Puimedon asegurap@redhat.com
