### PR TITLE
iproute: use the table 254 by default in get_default_routes()

### DIFF
--- a/pyroute2/netlink/iproute.py
+++ b/pyroute2/netlink/iproute.py
@@ -541,7 +541,7 @@ class IPRoute(Netlink):
     # removed due to redundancy. Only link shortcuts are left here for
     # now. Possibly, they should be moved to a separate module.
     #
-    def get_default_routes(self, family=AF_UNSPEC, table=None):
+    def get_default_routes(self, family=AF_UNSPEC, table=254):
         '''
         Get default routes
         '''


### PR DESCRIPTION
Before this patch, get_default_routes() uses a default table value
of None, which causes an exception in encode() (netlink/generic.py
line 410) when trying to pack a None value.
