### PR TITLE
IFA_FLAGS support

### DIFF
--- a/pyroute2/netlink/rtnl/ifaddrmsg.py
+++ b/pyroute2/netlink/rtnl/ifaddrmsg.py
@@ -38,7 +38,8 @@ class ifaddrmsg(nlmsg):
                ('IFA_BROADCAST', 'ipaddr'),
                ('IFA_ANYCAST', 'ipaddr'),
                ('IFA_CACHEINFO', 'cacheinfo'),
-               ('IFA_MULTICAST', 'ipaddr'))
+               ('IFA_MULTICAST', 'ipaddr'),
+               ('IFA_FLAGS', 'uint32'))
 
     class cacheinfo(nla):
         fields = (('ifa_prefered', 'I'),


### PR DESCRIPTION
`IFA_FLAGS` is a u32 attribute that extends the u8 field `ifa_flags`. If present, the value from `struct ifaddrmsg` will be ignored.

Currently two flags are stored in IFA_FLAGS: `IFA_F_MANAGETEMPADDR` and `IFA_F_NOPREFIXROUTE` which are useful for ipv6 SLAAC support.
