### PR TITLE
Using git describe in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # Pyroute version and release
 #
 version ?= "0.3"
-release ?= "0.3.2rc2"
+release := $(shell git describe)
 ##
 # Python and nosetests versions
 #


### PR DESCRIPTION
With using `git describe` in the Makefile it is easy to package the
application by just creating a new git tag.

Might be interesting for creating version strings:
https://wiki.debian.org/Punctuation

For example:
the checkout of the git tag `0.3.2rc1` will return exactly that git tag.
When developing further and creating a new tar.gz for distribution
it will return with the current head `0.3.2rc1-21-g8bef118`.
This string contains the last tag, number of commits after the last
tag and the current commit id.
