### PR TITLE
Update __init__.py

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -846,6 +846,9 @@ class nlmsg_base(dict):
                     length = len(value) + 1
                     fmt = '%is' % (length)
 
+                if isinstance(value, unicode):
+                    value = str(value)
+
                 # in python3 we should force it
                 if sys.version[0] == '3':
                     if isinstance(value, str):


### PR DESCRIPTION
fix  stuct pack error caused by the following scripts when using python2.x:

```
#!/usr/bin/python -O
from pyroute2 import IPRoute
ipr = IPRoute()
dev = ipr.link_lookup(ifname=str('eth0'))[0]
```
