### PR TITLE
Allow mask positional argurment to also accept dotted quad notation

### DIFF
--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -232,6 +232,8 @@ class Interface(Transactional):
                 mask = dqn2int(mask)
             else:
                 mask = int(mask, 0)
+        elif isinstance(mask, basestring):
+            mask = dqn2int(mask)
         brd = brd or broadcast
         # FIXME: make it more generic
         # skip IPv6 link-local addresses


### PR DESCRIPTION
Currently the following work:

~~~python
eno1.add_ip('10.10.0.8/24')
eno1.add_ip('10.10.0.8/255.255.255.0')
eno1.add_ip('10.10.0.8', mask=24)
~~~

but this one doesn't

~~~python
eno1.add_ip('10.10.0.8', mask='255.255.255.0')
~~~

This patch makes it easier to integrate the dhcp support:

~~~python
reply = dhcp('eno1')
yiaddr = reply['yiaddr']
subnet_mask = reply['options']['subnet_mask']

with eno1:
    eno1.add_ip(yiaddr, mask=subnet_mask)
~~~

As the subnet_mask comes in dotted quad notation.