### PR TITLE
Improvement for iw.scan()

### DIFF
--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -143,6 +143,8 @@ NL80211_CMD_MAX = NL80211_CMD_WIPHY_REG_CHANGE
 NL80211_BSS_ELEMENTS_SSID = 0
 NL80211_BSS_ELEMENTS_SUPPORTED_RATES = 1
 NL80211_BSS_ELEMENTS_CHANNEL = 3
+NL80211_BSS_ELEMENTS_TIM = 5
+NL80211_BSS_ELEMENTS_EXTENDED_RATE = 50
 NL80211_BSS_ELEMENTS_VENDOR = 221
 
 BSS_MEMBERSHIP_SELECTOR_HT_PHY = 127
@@ -164,6 +166,19 @@ NL80211_IFTYPE_OCB = 11
 (IFTYPE_NAMES, IFTYPE_VALUES) = map_namespace('NL80211_IFTYPE_',
                                               globals(),
                                               normalize=True)
+
+# channel width
+NL80211_CHAN_WIDTH_20_NOHT = 0  # 20 MHz non-HT channel
+NL80211_CHAN_WIDTH_20 = 1       # 20 MHz HT channel
+NL80211_CHAN_WIDTH_40 = 2       # 40 MHz HT channel
+NL80211_CHAN_WIDTH_80 = 3       # 80 MHz channel
+NL80211_CHAN_WIDTH_80P80 = 4    # 80+80 MHz channel
+NL80211_CHAN_WIDTH_160 = 5      # 160 MHz channel
+NL80211_CHAN_WIDTH_5 = 6        # 5 MHz OFDM channel
+NL80211_CHAN_WIDTH_10 = 7       # 10 MHz OFDM channel
+(CHAN_WIDTH, WIDTH_VALUES) = map_namespace('NL80211_CHAN_WIDTH_',
+                                           globals(),
+                                           normalize=True)
 
 
 class nl80211cmd(genlmsg):
@@ -219,7 +234,7 @@ class nl80211cmd(genlmsg):
                ('NL80211_ATTR_REG_TYPE', 'hex'),
                ('NL80211_ATTR_SUPPORTED_COMMANDS', 'hex'),
                ('NL80211_ATTR_FRAME', 'hex'),
-               ('NL80211_ATTR_SSID', 'hex'),
+               ('NL80211_ATTR_SSID', 'asciiz'),
                ('NL80211_ATTR_AUTH_TYPE', 'hex'),
                ('NL80211_ATTR_REASON_CODE', 'hex'),
                ('NL80211_ATTR_KEY_TYPE', 'hex'),
@@ -389,11 +404,11 @@ class nl80211cmd(genlmsg):
     class bss(nla):
         class elementsBinary(nla_base):
 
-            def binary_supported_rates(self, rawdata):
+            def binary_rates(self, rawdata):
                 # pdb.set_trace()
                 string = ""
                 for byteRaw in rawdata:
-                    (byte,) = struct.unpack("B", byteRaw)
+                    (byte,) = struct.unpack("B", bytearray([byteRaw])[0:1])
                     r = byte & 0x7f
 
                     if r == BSS_MEMBERSHIP_SELECTOR_VHT_PHY and byte & 0x80:
@@ -406,6 +421,14 @@ class nl80211cmd(genlmsg):
                     string += "%s " % ("*" if byte & 0x80 else "")
 
                 return string
+
+            def binary_tim(self, data):
+                (count,) = struct.unpack("B", data[0:1])
+                (period,) = struct.unpack("B", data[1:2])
+                (bitmapc,) = struct.unpack("B", data[2:3])
+                (bitmap0,) = struct.unpack("B", data[3:4])
+                return ("DTIM Count {0} DTIM Period {1} Bitmap Control 0x{2} "
+                        "Bitmap[0] 0x{3}".format(count, period, bitmapc, bitmap0))
 
             def binary_vendor(self, rawdata):
                 '''
@@ -440,12 +463,19 @@ class nl80211cmd(genlmsg):
                         self.value["SSID"] = data
 
                     if msg_type == NL80211_BSS_ELEMENTS_SUPPORTED_RATES:
-                        supported_rates = self.binary_supported_rates(data)
+                        supported_rates = self.binary_rates(data)
                         self.value["SUPPORTED_RATES"] = supported_rates
 
                     if msg_type == NL80211_BSS_ELEMENTS_CHANNEL:
-                        (channel,) = struct.unpack("B", data[0])
+                        (channel,) = struct.unpack("B", data[0:1])
                         self.value["CHANNEL"] = channel
+
+                    if msg_type == NL80211_BSS_ELEMENTS_TIM:
+                        self.value["TRAFFIC INDICATION MAP"] = self.binary_tim(data)
+
+                    if msg_type == NL80211_BSS_ELEMENTS_EXTENDED_RATE:
+                        extended_rates = self.binary_rates(data)
+                        self.value["EXTENDED_RATES"] = extended_rates
 
                     if msg_type == NL80211_BSS_ELEMENTS_VENDOR:
                         self.binary_vendor(data)
@@ -453,18 +483,20 @@ class nl80211cmd(genlmsg):
                 self.buf.seek(init)
 
         prefix = 'NL80211_BSS_'
-        nla_map = (('NL80211_BSS_UNSPEC', 'none'),
+        nla_map = (('NL80211_BSS_SIGNAL_UNSPEC', 'uint8'),
                    ('NL80211_BSS_BSSID', 'hex'),
                    ('NL80211_BSS_FREQUENCY', 'uint32'),
                    ('NL80211_BSS_TSF', 'uint64'),
                    ('NL80211_BSS_BEACON_INTERVAL', 'uint16'),
-                   ('NL80211_BSS_CAPABILITY', 'uint8'),
+                   ('NL80211_BSS_CAPABILITY', 'uint16'),
                    ('NL80211_BSS_INFORMATION_ELEMENTS', 'elementsBinary'),
                    ('NL80211_BSS_SIGNAL_MBM', 'uint32'),
                    ('NL80211_BSS_STATUS', 'uint32'),
                    ('NL80211_BSS_SEEN_MS_AGO', 'uint32'),
                    ('NL80211_BSS_BEACON_IES', 'hex'),
                    ('NL80211_BSS_CHAN_WIDTH', 'uint32'),
+                   ('NL80211_BSS_PRESP_DATA', 'hex'),
+                   ('NL80211_BSS_MAX', 'hex'),
                    ('NL80211_BSS_BEACON_TSF', 'uint64')
                    )
 

--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -167,19 +167,6 @@ NL80211_IFTYPE_OCB = 11
                                               globals(),
                                               normalize=True)
 
-# channel width
-NL80211_CHAN_WIDTH_20_NOHT = 0  # 20 MHz non-HT channel
-NL80211_CHAN_WIDTH_20 = 1       # 20 MHz HT channel
-NL80211_CHAN_WIDTH_40 = 2       # 40 MHz HT channel
-NL80211_CHAN_WIDTH_80 = 3       # 80 MHz channel
-NL80211_CHAN_WIDTH_80P80 = 4    # 80+80 MHz channel
-NL80211_CHAN_WIDTH_160 = 5      # 160 MHz channel
-NL80211_CHAN_WIDTH_5 = 6        # 5 MHz OFDM channel
-NL80211_CHAN_WIDTH_10 = 7       # 10 MHz OFDM channel
-(CHAN_WIDTH, WIDTH_VALUES) = map_namespace('NL80211_CHAN_WIDTH_',
-                                           globals(),
-                                           normalize=True)
-
 
 class nl80211cmd(genlmsg):
     nla_map = (('NL80211_ATTR_UNSPEC', 'none'),


### PR DESCRIPTION
This pull request does the following tasks:

- Correct the `TypeError` while printing out the `NL80211_BSS_INFORMATION_ELEMENTS` attribute
- Add traffic indication map (`NL80211_BSS_ELEMENTS_TIM`) and extended supported rate (`NL80211_BSS_ELEMENTS_EXTENDED_RATE`) in the scan results