### PR TITLE
Null terminator for SSID

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1331,6 +1331,19 @@ class nlmsg_atoms(nlmsg_base):
         '''
         fields = [('value', 's')]
 
+        def encode(self):
+            if isinstance(self['value'], str) and sys.version[0] == '3':
+                self['value'] = bytes(self['value'], 'utf-8')
+            nla_base.encode(self)
+
+        def decode(self):
+            nla_base.decode(self)
+            try:
+                assert sys.version[0] == '3'
+                self.value = self['value'].decode('utf-8')
+            except (AssertionError, UnicodeDecodeError):
+                self.value = self['value']
+
     class asciiz(nla_base):
         '''
         Zero-terminated string.

--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1325,13 +1325,11 @@ class nlmsg_atoms(nlmsg_base):
             fmt = '%s%i%s' % (self.fmt[:-1], array_size, self.fmt[-1:])
             self.value = struct.unpack(fmt, data)
 
-
     class cdata(nla_base):
         '''
         Binary data
         '''
         fields = [('value', 's')]
-
 
     class string(nla_base):
         '''
@@ -1351,7 +1349,6 @@ class nlmsg_atoms(nlmsg_base):
                 self.value = self['value'].decode('utf-8')
             except (AssertionError, UnicodeDecodeError):
                 self.value = self['value']
-
 
     class asciiz(nla_base):
         '''

--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1325,9 +1325,17 @@ class nlmsg_atoms(nlmsg_base):
             fmt = '%s%i%s' % (self.fmt[:-1], array_size, self.fmt[-1:])
             self.value = struct.unpack(fmt, data)
 
+
     class cdata(nla_base):
         '''
         Binary data
+        '''
+        fields = [('value', 's')]
+
+
+    class string(nla_base):
+        '''
+        Plain string
         '''
         fields = [('value', 's')]
 
@@ -1343,6 +1351,7 @@ class nlmsg_atoms(nlmsg_base):
                 self.value = self['value'].decode('utf-8')
             except (AssertionError, UnicodeDecodeError):
                 self.value = self['value']
+
 
     class asciiz(nla_base):
         '''

--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -235,7 +235,7 @@ class nl80211cmd(genlmsg):
                ('NL80211_ATTR_REG_TYPE', 'hex'),
                ('NL80211_ATTR_SUPPORTED_COMMANDS', 'hex'),
                ('NL80211_ATTR_FRAME', 'hex'),
-               ('NL80211_ATTR_SSID', 'asciiz'),
+               ('NL80211_ATTR_SSID', 'cdata'),
                ('NL80211_ATTR_AUTH_TYPE', 'hex'),
                ('NL80211_ATTR_REASON_CODE', 'hex'),
                ('NL80211_ATTR_KEY_TYPE', 'hex'),

--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -235,7 +235,7 @@ class nl80211cmd(genlmsg):
                ('NL80211_ATTR_REG_TYPE', 'hex'),
                ('NL80211_ATTR_SUPPORTED_COMMANDS', 'hex'),
                ('NL80211_ATTR_FRAME', 'hex'),
-               ('NL80211_ATTR_SSID', 'cdata'),
+               ('NL80211_ATTR_SSID', 'string'),
                ('NL80211_ATTR_AUTH_TYPE', 'hex'),
                ('NL80211_ATTR_REASON_CODE', 'hex'),
                ('NL80211_ATTR_KEY_TYPE', 'hex'),


### PR DESCRIPTION
This pull request solve the problem https://github.com/svinota/pyroute2/issues/144 that the station cannot really connect to mesh network via `join_ibss` because the ending null terminator of `AATR_SSID`. The following code snippet is the output of the `iw dev`.
```
Interface adhoc0
    ifindex 10
    wdev 0x2
    addr aa:dd:db:00:01:a3
    ssid mesh-network\x00
    type IBSS
    channel 36 (5180 MHz), width: 40 MHz, center1: 5190 MHz
```

Note that there is an syntax error when I run the `flake8` in the file that I did not edit...
```
pyroute2/netns/process/base_p3.py:4:37: E901 SyntaxError: invalid syntax 
```