### PR TITLE
Change type of ATTR_SSID to string

### DIFF
--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -235,7 +235,7 @@ class nl80211cmd(genlmsg):
                ('NL80211_ATTR_REG_TYPE', 'hex'),
                ('NL80211_ATTR_SUPPORTED_COMMANDS', 'hex'),
                ('NL80211_ATTR_FRAME', 'hex'),
-               ('NL80211_ATTR_SSID', 'asciiz'),
+               ('NL80211_ATTR_SSID', 'string'),
                ('NL80211_ATTR_AUTH_TYPE', 'hex'),
                ('NL80211_ATTR_REASON_CODE', 'hex'),
                ('NL80211_ATTR_KEY_TYPE', 'hex'),


### PR DESCRIPTION
It is targeting to solve the null terminator at the end of SSID revealing by `iw dev`. https://github.com/svinota/pyroute2/issues/144