### PR TITLE
Add BPF filter support to tcmsg

### DIFF
--- a/pyroute2/iproute.py
+++ b/pyroute2/iproute.py
@@ -110,6 +110,7 @@ from pyroute2.netlink.rtnl.tcmsg import get_sfq_parameters
 from pyroute2.netlink.rtnl.tcmsg import get_u32_parameters
 from pyroute2.netlink.rtnl.tcmsg import get_netem_parameters
 from pyroute2.netlink.rtnl.tcmsg import get_fw_parameters
+from pyroute2.netlink.rtnl.tcmsg import get_bpf_parameters
 from pyroute2.netlink.rtnl.tcmsg import tcmsg
 from pyroute2.netlink.rtnl.rtmsg import rtmsg
 from pyroute2.netlink.rtnl.ndmsg import ndmsg
@@ -120,6 +121,7 @@ from pyroute2.netlink.rtnl.ifinfmsg import ifinfmsg
 from pyroute2.netlink.rtnl.ifaddrmsg import ifaddrmsg
 from pyroute2.netlink.rtnl.iprsocket import IPRSocket
 from pyroute2.netlink.rtnl.iprsocket import RawIPRSocket
+from pyroute2.protocols import ETH_P_ALL
 
 from pyroute2.common import basestring
 
@@ -848,6 +850,12 @@ class IPRouteMixin(object):
                 ((kwarg.get('prio', 0) << 16) & 0xffff0000)
             if kwarg:
                 opts = get_fw_parameters(kwarg)
+        elif kind == 'bpf':
+            msg['parent'] = kwarg.get('parent', TC_H_ROOT)
+            msg['info'] = htons(kwarg.get('protocol', ETH_P_ALL) & 0xffff) |\
+                ((kwarg.get('prio', 0) << 16) & 0xffff0000)
+            if kwarg:
+                opts = get_bpf_parameters(kwarg)
         else:
             msg['parent'] = kwarg.get('parent', TC_H_ROOT)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,7 @@ import sys
 import errno
 import platform
 import subprocess
+import ctypes
 from pyroute2.netlink import NetlinkError
 from pyroute2.netlink.rtnl.ifinfmsg import compat_create_bridge
 from pyroute2.netlink.rtnl.ifinfmsg import compat_create_bond
@@ -183,3 +184,50 @@ def get_ip_rules(proto='-4'):
         if len(string):
             ret.append(string)
     return ret
+
+
+def get_bpf_syscall_num():
+    # determine bpf syscall number
+    prog = """
+#include <asm/unistd.h>
+#define XSTR(x) STR(x)
+#define STR(x) #x
+#pragma message "__NR_bpf=" XSTR(__NR_bpf)
+"""
+    cmd = ['gcc', '-x', 'c', '-c', '-', '-o', '/dev/null']
+    gcc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    out = gcc.communicate(input=prog.encode('ascii'))[1]
+    m = re.search('__NR_bpf=([0-9]+)', str(out))
+    if not m:
+        raise SkipTest('bpf syscall not available')
+    return int(m.group(1))
+
+
+def get_simple_bpf_program():
+    NR_bpf = get_bpf_syscall_num()
+
+    class BPFAttr(ctypes.Structure):
+        _fields_ = [('prog_type', ctypes.c_uint),
+                    ('insn_cnt', ctypes.c_uint),
+                    ('insns', ctypes.POINTER(ctypes.c_ulonglong)),
+                    ('license', ctypes.c_char_p),
+                    ('log_level', ctypes.c_uint),
+                    ('log_size', ctypes.c_uint),
+                    ('log_buf', ctypes.c_char_p),
+                    ('kern_version', ctypes.c_uint)]
+
+    BPF_PROG_TYPE_SCHED_CLS = 3
+    BPF_PROG_LOAD = 5
+    insns = (ctypes.c_ulonglong * 2)()
+    # equivalent to: int my_func(void *) { return 1; }
+    insns[0] = 0x00000001000000b7
+    insns[1] = 0x0000000000000095
+    license = ctypes.c_char_p(b'GPL')
+    attr = BPFAttr(BPF_PROG_TYPE_SCHED_CLS, len(insns),
+                   insns, license, 0, 0, None, 0)
+    libc = ctypes.CDLL('libc.so.6')
+    libc.syscall.argtypes = [ctypes.c_long, ctypes.c_int,
+                             ctypes.POINTER(type(attr)), ctypes.c_uint]
+    libc.syscall.restype = ctypes.c_int
+    fd = libc.syscall(NR_bpf, BPF_PROG_LOAD, attr, ctypes.sizeof(attr))
+    return fd


### PR DESCRIPTION
This change requires at least the bpf syscall (linux >4.0 or so, CONFIG_BPF_SYSCALL=y) as well as option CONFIG_NET_CLS_BPF=m/y. A similar feature is going into iproute2 net-next branch (http://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git?h=net-next)

To effectively use this feature, one needs to have opened a BPF program and have an open fd handle to give to the tc filter. Doing that is outside the scope of this commit, and other tools are in progress to support this. This commit includes a test case which exercises the feature without creating a dependency on those tools.