### PR TITLE
Set ChanWidth for Join IBSS even if below 40 MHz

### DIFF
--- a/pyroute2/iwutil.py
+++ b/pyroute2/iwutil.py
@@ -353,7 +353,7 @@ class IW(NL80211):
                 msg['attrs'].append(['NL80211_ATTR_CENTER_FREQ1', center])
                 msg['attrs'].append(['NL80211_ATTR_CENTER_FREQ2', center2])
             elif width in [0, 1, 6, 7]:
-                pass  # 5-20 MHz doesn't need to specify a center
+                msg['attrs'].append(['NL80211_ATTR_CHANNEL_WIDTH', width])
             else:
                 raise TypeError('No channel specified')
 


### PR DESCRIPTION
Previously we ignored the CHANNEL_WIDTH attribute for all widths under 40 MHz, which defaults them all to 20 MHz No-HT. This pull request will set them to the correct value.