### PR TITLE
Mask SIGINT from netns child processes

### DIFF
--- a/pyroute2/netns/nslink.py
+++ b/pyroute2/netns/nslink.py
@@ -68,6 +68,7 @@ import os
 import errno
 import atexit
 import select
+import signal
 import struct
 import threading
 import traceback
@@ -126,6 +127,7 @@ def NetNServer(netns, rcvch, cmdch, flags=os.O_CREAT):
            implementations, but it is required by the protocol standard.
 
     '''
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
         nsfd = setns(netns, flags)
     except OSError as e:


### PR DESCRIPTION
By default, pressing Ctrl-C on the keyboard when running a python
process in the foreground sends SIGINT to all processes in the
hierarchy, which results in the cleanup+wait of the parent waiting on
some message from the child, which is also cleaning itself up. To avoid
this, mask SIGINT in the children. This places a burden on the parent to
always wait on the child, but avoids the deadlock.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>