### PR TITLE
Remove IFLA_VXLAN_FLOWBASED flag from ifinfmsg

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg.py
@@ -403,7 +403,6 @@ class ifinfbase(object):
                        ('IFLA_VXLAN_GBP', 'uint8'),
                        # NLA_FLAG, not implemented?
                        ('IFLA_VXLAN_REMCSUM_NOPARTIAL', 'uint8'),
-                       ('IFLA_VXLAN_FLOWBASED', 'uint8'),
                        ('IFLA_VXLAN_COLLECT_METADATA', 'uint8'))
 
             class port_range(nla):


### PR DESCRIPTION
This option was combined with the IFLA_VXLAN_COLLECT_METADATA option,
and the FLOWBASED flag is removed from net-next before merging with
-stable branch. Hopefully there are no more changes in the enum.

See https://patchwork.ozlabs.org/patch/503901/

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>