### PR TITLE
Actually set the FREQ_FIXED flag

### DIFF
--- a/pyroute2/iwutil.py
+++ b/pyroute2/iwutil.py
@@ -343,7 +343,7 @@ class IW(NL80211):
                         ['NL80211_ATTR_WIPHY_FREQ', freq]]
 
         if channel_fixed:
-            msg['attrs'].append(['NL80211_ATTR_FREQ_FIXED'], None])
+            msg['attrs'].append(['NL80211_ATTR_FREQ_FIXED', None])
             width = CHAN_WIDTH.get(width, width)
             assert isinstance(width, int)
             if width in [2, 3, 5] and center:

--- a/pyroute2/iwutil.py
+++ b/pyroute2/iwutil.py
@@ -343,6 +343,7 @@ class IW(NL80211):
                         ['NL80211_ATTR_WIPHY_FREQ', freq]]
 
         if channel_fixed:
+            msg['attrs'].append(['NL80211_ATTR_FREQ_FIXED'], None])
             width = CHAN_WIDTH.get(width, width)
             assert isinstance(width, int)
             if width in [2, 3, 5] and center:


### PR DESCRIPTION
This is a flag, so it has a payload of NULL in the netlink `nla_put_flag` command. We previously were not setting this flag, which resulted in off-channel scans despite us setting a fixed frequency.