### PR TITLE
Add more routing attributes

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1300,6 +1300,9 @@ class nlmsg_atoms(nlmsg_base):
     class uint64(nla_base):
         fields = [('value', 'Q')]
 
+    class int32(nla_base):
+        fields = [('value', 'i')]
+
     class be8(nla_base):
         fields = [('value', '>B')]
 

--- a/pyroute2/netlink/rtnl/ifinfmsg.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg.py
@@ -198,7 +198,10 @@ class ifinfbase(object):
                ('IFLA_NUM_RX_QUEUES', 'uint32'),
                ('IFLA_CARRIER', 'uint8'),
                ('IFLA_PHYS_PORT_ID', 'hex'),
-               ('IFLA_CARRIER_CHANGES', 'uint32'))
+               ('IFLA_CARRIER_CHANGES', 'uint32'),
+               ('IFLA_PHYS_SWITCH_ID', 'hex'),
+               ('IFLA_LINK_NETNSID', 'int32'),
+               ('IFLA_PHYS_PORT_NAME', 'asciiz'))
 
     @staticmethod
     def flags2names(flags, mask=0xffffffff):


### PR DESCRIPTION
Adds some more recent routing attributes:
    
- `IFLA_PHYS_SWITCH_ID`
- `IFLA_LINK_NETNSID`
- `IFLA_PHYS_PORT_NAME`

All indications show that `IFLA_LINK_NETNSID` is signed but I could be wrong.