### PR TITLE
Remove hanging code from reverted commit

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -926,8 +926,6 @@ class nlmsg_base(dict):
             del self['attrs']
         if self['value'] is NotInitialized:
             del self['value']
-        if self.length:
-            self.buf.seek(self.msg_align(self.offset + self.length))
 
     def encode(self):
         '''


### PR DESCRIPTION
There was an incomplete revert of commits on Aug 11:
https://github.com/svinota/pyroute2/commit/7b27abd65f3a40405f5618370ade113fc2806c6a
https://github.com/svinota/pyroute2/commit/16a8aced82c65b94eb9e15a7d773a3256763d155

We had trouble decoding NL80211_BSS_INFORMATION_ELEMENTS until I removed these two lines and completed the revert. Many of the information elements were incomplete or incorrect - this pull request fixes that.