### PR TITLE
WIP: Add example tc add-filter for IP & subnet matching on src/dst

### DIFF
--- a/pyroute2/iproute.py
+++ b/pyroute2/iproute.py
@@ -792,6 +792,12 @@ class IPRouteMixin(object):
             ff:0   ->   0xff0000
             ffff:1 -> 0xffff0001
 
+        Target notice: if your target is a class/qdisc that applies an
+        algorithm that can only apply to upstream traffic profile, but your
+        keys variable explicitly references a match that is only relevant for
+        upstream traffic, the kernel will reject the filter.  Unless you're
+        dealing with devices like IMQs
+
         For pyroute2 tc() you can use both forms: integer like 0xffff0000
         or string like 'ffff:0000'. By default, handle is 0, so you can add
         simple classless queues w/o need to specify handle. Ingress queue

--- a/pyroute2/iproute.py
+++ b/pyroute2/iproute.py
@@ -894,6 +894,28 @@ class IPRouteMixin(object):
                   keys=["0x0/0x0+0"],
                   action=action)
 
+            # Add two more filters: One to send packets with a src address of
+            # 192.168.0.1/32 into 1:10 and the second to send packets  with a
+            # dst address of 192.168.0.0/24 into 1:20
+            ip.tc("add-filter", "u32", eth0,
+                parent=0x10000,
+                prio=10,
+                protocol=socket.AF_INET,
+                target=0x10010,
+                keys=["0xc0a80001/0xffffffff+12"])
+                # 0xc0a800010 = 192.168.0.1
+                # 0xffffffff = 255.255.255.255 (/32)
+                # 12 = Source network field bit offset
+
+            ip.tc("add-filter", "u32", eth0,
+                parent=0x10000,
+                prio=10,
+                protocol=socket.AF_INET,
+                target=0x10020,
+                keys=["0xc0a80000/0xffffff00+16"])
+                # 0xc0a80000 = 192.168.0.0
+                # 0xffffff00 = 255.255.255.0 (/24)
+                # 16 = Destination network field bit offset
         '''
         flags_base = NLM_F_REQUEST | NLM_F_ACK
         flags_make = flags_base | NLM_F_CREATE | NLM_F_EXCL


### PR DESCRIPTION
### Overview
- Add some documentation to for quick-reference on creating `tc` filters for matching on source *or* destination IP/subnet.
- Bit offsets were discovered by using `tc` to add filters via CLI, assessing the output, and re-creating with pyroute2.
- Fixes #185 

### Issues Blocking Merge
1. ~~Resolve merge conflict~~
1. ~~This example is only applicable for interfaces, such as [IMQ]() devices~~

    *@svinota requests this being annotated in the docstring* *(See [a7f83955](https://github.com/tomislacker/pyroute2/commit/a7f83955d6c159785835b3234f7594118273a3cb))*
    
    If you're using classes/qdiscs that aren't available for upstream traffic control, I believe filter additions will be rejected by the kernel that match on destination host and have their `target` set to such a class/qdisc