### PR TITLE
Handling FRA_FWMASK parameter when calling IPRoute.rule()

### DIFF
--- a/pyroute2/iproute.py
+++ b/pyroute2/iproute.py
@@ -1194,6 +1194,9 @@ class IPRouteMixin(object):
         msg['attrs'].append(['FRA_PRIORITY', kwarg.get('priority', 32000)])
         if 'fwmark' in kwarg:
             msg['attrs'].append(['FRA_FWMARK', kwarg['fwmark']])
+
+            if 'FRA_FWMASK' in kwarg:
+                msg['attrs'].append(['FRA_FWMASK', kwarg['FRA_FWMASK']])
         if 'dst_len' in kwarg:
             msg['dst_len'] = kwarg['dst_len']
         if 'src_len' in kwarg:

--- a/tests/general/test_rule.py
+++ b/tests/general/test_rule.py
@@ -38,6 +38,20 @@ class TestRule(object):
                     x.get_attr('FRA_TABLE') == 15 and
                     x.get_attr('FRA_FWMARK')]) == 0
 
+    def test_fwmark_mask(self):
+        self.ip.rule('add', 15, 32006, fwmark=10, FRA_FWMASK=20)
+        assert len([x for x in self.ip.get_rules() if
+                    x.get_attr('FRA_PRIORITY') == 32006 and
+                    x.get_attr('FRA_TABLE') == 15 and
+                    x.get_attr('FRA_FWMARK') and
+                    x.get_attr('FRA_FWMASK')]) == 1
+        self.ip.rule('delete', 15, 32006, fwmark=10, FRA_FWMASK=20)
+        assert len([x for x in self.ip.get_rules() if
+                    x.get_attr('FRA_PRIORITY') == 32006 and
+                    x.get_attr('FRA_TABLE') == 15 and
+                    x.get_attr('FRA_FWMARK') and
+                    x.get_attr('FRA_FWMASK')]) == 0
+
     def test_bad_table(self):
         try:
             self.ip.rule('add', -1, 32000)


### PR DESCRIPTION
This would allow for inserting iproute2 rules with masked `fwmark` parameters as discussed in #187 