### PR TITLE
make Dotkeys compliant with hasattr protocol

### DIFF
--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -189,8 +189,10 @@ class Dotkeys(dict):
                     self[key[4:]] = value
                     return self
                 return set_value
-            else:
+            elif key in self:
                 return self[key]
+            else:
+                raise e
 
     def __setattr__(self, key, value):
         if key in self:

--- a/tests/general/test_ipdb.py
+++ b/tests/general/test_ipdb.py
@@ -167,6 +167,8 @@ class TestExplicit(object):
         del self.ip.interfaces.newitem
         del self.ip.interfaces.newattr
         assert 'newattr' not in dir(self.ip.interfaces)
+        # test hasattr protocol
+        assert hasattr(self.ip.interfaces, 'nonexistinginterface') is False
 
     @skip_if_not_supported
     def test_vlan_slave_bridge(self):


### PR DESCRIPTION
Current implementation of `__getattribute__` in Dotkeys doesn't throw AttributeError if a requested attribute cannot be found. Instead, `KeyError` is thrown and it breaks hasattr as the latter determines non-existence of an attribute by [catching](https://github.com/python/cpython/blob/master/Python/bltinmodule.c#L1051) `AttributeError`.

The change enables rpyc & pyroute2 interopability to manage network on a remote system.