### PR TITLE
Change the RTA_FLOW data type to uint32

### DIFF
--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -53,7 +53,7 @@ class rtmsg_base(object):
                ('RTA_METRICS', 'metrics'),
                ('RTA_MULTIPATH', '*get_nh'),
                ('RTA_PROTOINFO', 'uint32'),
-               ('RTA_FLOW', 'hex'),
+               ('RTA_FLOW', 'uint32'),
                ('RTA_CACHEINFO', 'cacheinfo'),
                ('RTA_SESSION', 'hex'),
                ('RTA_MP_ALGO', 'hex'),


### PR DESCRIPTION
RTA_FLOW is defined as unsigned 32b number, consisting of two 16 bit
fields to distinguish source/destination realms. Related code in
iproute2 to interpret the value:

```
    if (tb[RTA_FLOW] && filter.realmmask != ~0U) {
        __u32 to = rta_getattr_u32(tb[RTA_FLOW]);
        __u32 from = to>>16;
        to &= 0xFFFF;
        fprintf(fp, "realm%s ", from ? "s" : "");
        if (from) {
            fprintf(fp, "%s/",
                rtnl_rtrealm_n2a(from, b1, sizeof(b1)));
        }
        fprintf(fp, "%s ",
            rtnl_rtrealm_n2a(to, b1, sizeof(b1)));
    }
```

The following snippet


```
ipr = pyroute2.IPRoute()
r = pyroute2.IPRouteRequest({'family': socket.AF_INET, 'dst': \
"192.168.0.0", 'mask': 24, "gateway": "10.42.6.1", "flow": 45})
ipr.route("add", **r)
```

fails with

```
Traceback (most recent call last):
  File "./test.py", line 7, in <module>
    ipr.route("add", **r)
  File "pyroute2/iproute.py", line 1652, in route
    ret = self.nlm_request(msg, msg_type=command, msg_flags=flags)
  File "pyroute2/netlink/nlsocket.py", line 786, in nlm_request
    return do_try()
  File "pyroute2/netlink/nlsocket.py", line 764, in do_try
    self.put(msg, msg_type, msg_flags, msg_seq=msg_seq)
  File "pyroute2/netlink/nlsocket.py", line 549, in put
    self.sendto_gate(msg, addr)
  File "pyroute2/netlink/rtnl/iprsocket.py", line 79, in _gate
    msg.encode()
  File "pyroute2/netlink/rtnl/rtmsg.py", line 158, in encode
    nlmsg.encode(self)
  File "pyroute2/netlink/__init__.py", line 1007, in encode
    offset = self.encode_nlas(offset)
  File "pyroute2/netlink/__init__.py", line 1316, in encode_nlas
    nla.encode()
  File "pyroute2/netlink/__init__.py", line 965, in encode
    length = len(value)
TypeError: object of type 'int' has no len()
```