### PR TITLE
Add tox and make tests/run.sh agnostic to pyenv wrappers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/html
 docs/doctrees
 docs-build.log
 pyroute2.egg-info
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26,py27,py33,py34,py35
+platform = linux
+[testenv]
+deps = -rtests/requirements.txt
+whitelist_externals = make
+commands = {posargs:make test}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py26,py27,py32,py33,py34,py35
 platform = linux
 [testenv]
 deps = -rtests/requirements.txt


### PR DESCRIPTION
The easiest way to run tests with all versions of python is "tox".
It looks like this:
```
pyenv shell 2.6.9 2.7.11 3.3.6 3.4.4 3.5.1
tox
```
Tests will be run sequentially for each of the python versions.

However tests can also be run in a specific pyenv environment without
tox:
```
pyenv virtualenv 3.3.6 pyroute2-py33
pyenv activate pyroute2-py33
make test
```
`make test` can still use python that comes from linux distribution.