### PR TITLE
Fix typo.

### DIFF
--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -1193,7 +1193,7 @@ class NeighboursDict(dict):
         try:
             (self[msg['ifindex']]
              .add(key=msg.get_attr('NDA_DST'),
-                  raw={'lladdr': msg.get_attr('MDA_LLADDR')}))
+                  raw={'lladdr': msg.get_attr('NDA_LLADDR')}))
         except:
             pass
 


### PR DESCRIPTION
This may be the cause for getting no MAC address in the snippet
bellow:

```
import pyroute2
ip = pyroute2.IPDB()
neigh = ip.interfaces['eth0]['neighbours']
neigh['192.168.1.10'].get('lladdr')
```

Assuming a neighbor with IP = 192.168.1.10 connected to the 'eth0'
interface, this would return the neighbor's MAC address.
But it returns 'None'.

The typo origin seems to be in revision dbb0128d, from 2016-05-01,
still at 'ipdb/main.py'.
It then was moved to 'ipdb/interface.py' in revision 64f9cfec,
from 2016-06-02.