### PR TITLE
Skip tests on the old kernels

### DIFF
--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -14,6 +14,7 @@ from pyroute2.netlink import nla_base
 
 # import pdb
 import struct
+import sys
 from pyroute2.common import hexdump
 
 # nl80211 commands
@@ -409,7 +410,9 @@ class nl80211cmd(genlmsg):
                 # pdb.set_trace()
                 string = ""
                 for byteRaw in rawdata:
-                    (byte,) = struct.unpack("B", bytearray([byteRaw])[0:1])
+                    if sys.version_info[0] > 2:
+                        byteRaw = bytearray([byteRaw])[0:1]
+                    (byte,) = struct.unpack("B", byteRaw)
                     r = byte & 0x7f
 
                     if r == BSS_MEMBERSHIP_SELECTOR_VHT_PHY and byte & 0x80:

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -661,6 +661,7 @@ class TestIPRoute(object):
     @skip_if_not_supported
     def test_lwtunnel_multipath_mpls(self):
         require_user('root')
+        require_kernel(4, 5)
         self.ip.route('add',
                       dst='172.16.216.0/24',
                       multipath=[{'encap': {'type': 'mpls',
@@ -691,6 +692,7 @@ class TestIPRoute(object):
     @skip_if_not_supported
     def test_lwtunnel_mpls_dict_label(self):
         require_user('root')
+        require_kernel(4, 3)
         self.ip.route('add',
                       dst='172.16.226.0/24',
                       encap={'type': 'mpls',
@@ -713,6 +715,7 @@ class TestIPRoute(object):
     @skip_if_not_supported
     def test_lwtunnel_mpls_2_int_label(self):
         require_user('root')
+        require_kernel(4, 3)
         self.ip.route('add',
                       dst='172.16.206.0/24',
                       encap={'type': 'mpls',
@@ -734,6 +737,7 @@ class TestIPRoute(object):
     @skip_if_not_supported
     def test_lwtunnel_mpls_2_str_label(self):
         require_user('root')
+        require_kernel(4, 3)
         self.ip.route('add',
                       dst='172.16.246.0/24',
                       encap={'type': 'mpls',
@@ -755,6 +759,7 @@ class TestIPRoute(object):
     @skip_if_not_supported
     def test_lwtunnel_mpls_1_str_label(self):
         require_user('root')
+        require_kernel(4, 3)
         self.ip.route('add',
                       dst='172.16.244.0/24',
                       encap={'type': 'mpls',
@@ -774,6 +779,7 @@ class TestIPRoute(object):
     @skip_if_not_supported
     def test_lwtunnel_mpls_1_int_label(self):
         require_user('root')
+        require_kernel(4, 3)
         self.ip.route('add',
                       dst='172.16.245.0/24',
                       encap={'type': 'mpls',

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -361,6 +361,7 @@ class TestIPRoute(object):
 
     def test_fdb_bridge_simple(self):
         require_user('root')
+        require_kernel(4, 4)
         # create bridge
         (bn, bx) = self._create('bridge')
         # create FDB record

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -8,6 +8,7 @@
 }
 
 export PYTHONPATH="`pwd`:`pwd`/examples"
+TOP=$(readlink -f $(pwd)/..)
 
 # Prepare test environment
 #
@@ -21,12 +22,15 @@ export PYTHONPATH="`pwd`:`pwd`/examples"
 # since in that case only those files will be tests, that
 # are included in the package.
 #
-cd ../dist
+# Tox installs the package into each environment, so we can safely skip
+# extraction of the packaged files
+if [ -z "$WITHINTOX" ]; then
+    cd "$TOP/dist"
     tar xf *
-    mv pyroute2*/pyroute2 ../tests/
-cd ../
-    cp -a examples ./tests/
-cd ./tests/
+    mv pyroute2*/pyroute2 "$TOP/tests/"
+fi
+cp -a "$TOP/examples" "$TOP/tests/"
+cd "$TOP/tests/"
 
 # Install test requirements, if not installed. If the user
 # is not root and all requirements are met, this step will

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35
+envlist = py26,py27,py33,py34,py35
 platform = linux
 [testenv]
 deps = -rtests/requirements.txt
 whitelist_externals = make
+                      /bin/sh
 commands = {posargs:make test}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py26,py27,py33,py34,py35
 platform = linux
 [testenv]
 deps = -rtests/requirements.txt
+setenv = WITHINTOX=1
 whitelist_externals = make
                       /bin/sh
 commands = {posargs:make test}


### PR DESCRIPTION
I'm trying to make all tests pass on supported versions of python. Some of the tests aren't intended to pass on very old kernels (<4).

I'm about to get all tests passing on Python 2.x. Probably there will be couple more changesets to fix issues on Python 3.x.

py32 tox environment is dropped as pip doesn't support Python 3.0-3.2.