### PR TITLE
ipdb: don't sort ipaddrs with empty flags.

### DIFF
--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -781,6 +781,7 @@ class Interface(Transactional):
             # secondaries first.
 
             r_addr = removed['ipaddr']
+
             def get_flags(x):
                 return self['ipaddr'][x]['flags']
             rip_not_sorted = [a for a in r_addr if get_flags(a) is not None]

--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -781,7 +781,8 @@ class Interface(Transactional):
             # secondaries first.
 
             r_addr = removed['ipaddr']
-            get_flags = lambda x: self['ipaddr'][x]['flags']
+            def get_flags(x):
+                return self['ipaddr'][x]['flags']
             rip_not_sorted = [a for a in r_addr if get_flags(a) is not None]
             rip_empty_flags = [a for a in r_addr if get_flags(a) is None]
 

--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -779,9 +779,16 @@ class Interface(Transactional):
             #
             # One simple way to work that around is to remove
             # secondaries first.
-            rip = sorted(removed['ipaddr'],
-                         key=lambda x: self['ipaddr'][x]['flags'],
+
+            r_addr = removed['ipaddr']
+            get_flags = lambda x: self['ipaddr'][x]['flags']
+            rip_not_sorted = [a for a in r_addr if get_flags(a) is not None]
+            rip_empty_flags = [a for a in r_addr if get_flags(a) is None]
+
+            rip = sorted(rip_not_sorted,
+                         key=get_flags,
                          reverse=True)
+            rip += rip_empty_flags
             # 8<--------------------------------------
             for i in rip:
                 # Ignore link-local IPv6 addresses


### PR DESCRIPTION
Python 3 has stricter comparison rules for None than Python 2 (i.e. None
cannot be compared with None, as TypeError is raised). We cannot rely on
sorted function for keys that might contain None. Therefore we sort only
ip addresses with non-None flags and then append addresses with empty
flags to the end.