### PR TITLE
use flags field if IFA_FLAGS attribute is not present in a NLA

### DIFF
--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -779,18 +779,9 @@ class Interface(Transactional):
             #
             # One simple way to work that around is to remove
             # secondaries first.
-
-            r_addr = removed['ipaddr']
-
-            def get_flags(x):
-                return self['ipaddr'][x]['flags']
-            rip_not_sorted = [a for a in r_addr if get_flags(a) is not None]
-            rip_empty_flags = [a for a in r_addr if get_flags(a) is None]
-
-            rip = sorted(rip_not_sorted,
-                         key=get_flags,
+            rip = sorted(removed['ipaddr'],
+                         key=lambda x: self['ipaddr'][x]['flags'],
                          reverse=True)
-            rip += rip_empty_flags
             # 8<--------------------------------------
             for i in rip:
                 # Ignore link-local IPv6 addresses

--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -1093,10 +1093,11 @@ class IPDB(object):
             if self.debug:
                 raw = addr
             else:
+                flags = addr.get_attr('IFA_FLAGS') or addr.get('flags')
                 raw = {'local': addr.get_attr('IFA_LOCAL'),
                        'broadcast': addr.get_attr('IFA_BROADCAST'),
                        'address': addr.get_attr('IFA_ADDRESS'),
-                       'flags': addr.get_attr('IFA_FLAGS') or addr.get('flags'),
+                       'flags': flags,
                        'prefixlen': addr.get('prefixlen')}
             if nla is not None:
                 try:

--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -1096,7 +1096,7 @@ class IPDB(object):
                 raw = {'local': addr.get_attr('IFA_LOCAL'),
                        'broadcast': addr.get_attr('IFA_BROADCAST'),
                        'address': addr.get_attr('IFA_ADDRESS'),
-                       'flags': addr.get_attr('IFA_FLAGS'),
+                       'flags': addr.get_attr('IFA_FLAGS') or addr.get('flags'),
                        'prefixlen': addr.get('prefixlen')}
             if nla is not None:
                 try:

--- a/tests/general/test_ipdb.py
+++ b/tests/general/test_ipdb.py
@@ -140,11 +140,13 @@ class TestExplicit(BasicSetup):
         index = self.ip.interfaces[if1]['index']
         addr = self.ip.nl.get_addr(index=index)[0]
         assert addr['scope'] == 254
+        assert self.ip.interfaces[if1].ipaddr[0]['flags'] is not None
         assert addr.get_attr('IFA_BROADCAST') is None
 
         index = self.ip.interfaces[if2]['index']
         addr = self.ip.nl.get_addr(index=index)[0]
         assert addr['scope'] == 0
+        assert self.ip.interfaces[if2].ipaddr[0]['flags'] is not None
         assert addr.get_attr('IFA_BROADCAST') == '172.16.103.128'
 
     def test_addr_loaded(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = linting,py26,py27,py33,py34,py35
 platform = linux
 [testenv]
 deps = -rtests/requirements.txt
@@ -7,3 +7,7 @@ setenv = WITHINTOX=1
 whitelist_externals = make
                       /bin/sh
 commands = {posargs:make test}
+[testenv:linting]
+basepython = python2.7
+deps = flake8
+commands = flake8


### PR DESCRIPTION
Kernel headers [prescribe](http://lxr.free-electrons.com/source/include/uapi/linux/if_addr.h?v=3.14#L22) to ignore `ifa_flags` field, only if `IFA_FLAGS` attribute is present. 