### PR TITLE
packaging: Support 0.4.x on both EPEL and Fedora

### DIFF
--- a/README.packages.md
+++ b/README.packages.md
@@ -10,3 +10,6 @@ packages/RedHat
 
 One common spec for all the RedHat flavours. To create RedHat
 package for the current running distro, run `make rpm`.
+
+NOTE: for python3 you should have python3-pkgversion-macros installed,
+available both on Fedora and EPEL.

--- a/packages/RedHat/python-pyroute2.spec
+++ b/packages/RedHat/python-pyroute2.spec
@@ -1,8 +1,10 @@
 %global srcname pyroute2
 %global sum Pure Python netlink library
 
+%{!?python3_pkgversion:%global python3_pkgversion 3}
+
 Name: python-%{srcname}
-Version: 0.3.19
+Version: 0.4.6
 Release: 1%{?dist}
 Summary: %{sum}
 License: GPLv2+
@@ -10,8 +12,9 @@ Group: Development/Languages
 URL: https://github.com/svinota/%{srcname}
 
 BuildArch: noarch
-BuildRequires: python2-devel python3-devel
-Source: https://pypi.python.org/packages/source/p/pyroute2/pyroute2-%{version}.tar.gz
+BuildRequires: python2-devel
+BuildRequires: python%{python3_pkgversion}-devel
+Source: https://pypi.io/packages/source/p/pyroute2/pyroute2-%{version}.tar.gz
 
 %description
 PyRoute2 provides several levels of API to work with Netlink
@@ -27,11 +30,11 @@ PyRoute2 provides several levels of API to work with Netlink
 protocols, such as Generic Netlink, RTNL, TaskStats, NFNetlink,
 IPQ.
 
-%package -n python3-%{srcname}
+%package -n python%{python3_pkgversion}-%{srcname}
 Summary: %{sum}
-%{?python_provide:%python_provide python3-%{srcname}}
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 
-%description -n python3-%{srcname}
+%description -n python%{python3_pkgversion}-%{srcname}
 PyRoute2 provides several levels of API to work with Netlink
 protocols, such as Generic Netlink, RTNL, TaskStats, NFNetlink,
 IPQ.
@@ -52,7 +55,7 @@ IPQ.
 %doc README* LICENSE.GPL.v2 LICENSE.Apache.v2
 %{python2_sitelib}/%{srcname}*
 
-%files -n python3-%{srcname}
+%files -n python%{python3_pkgversion}-%{srcname}
 %doc README* LICENSE.GPL.v2 LICENSE.Apache.v2
 %{python3_sitelib}/%{srcname}*
 


### PR DESCRIPTION
To successfully build on both EPEL and Fedora for Python3 there's some
macros that need to be used. This patch puts them in the specfile and
updates to the latest release.

Signed-off-by: Antoni Segura Puimedon <antonisp@celebdor.com>