### PR TITLE
Updated message data buffer reference

### DIFF
--- a/pyroute2/netlink/ipq/__init__.py
+++ b/pyroute2/netlink/ipq/__init__.py
@@ -114,7 +114,7 @@ class IPQSocket(NetlinkSocket):
         msg['header']['type'] = IPQM_MODE
         msg['header']['flags'] = NLM_F_REQUEST
         msg.encode()
-        self.sendto(msg.buf.getvalue(), (0, 0))
+        self.sendto(msg.data, (0, 0))
 
     def verdict(self, seq, v):
         '''


### PR DESCRIPTION
IPQ used debricated msg.buf.getvalue() and this changes it to use msg.data that I believe to be the right way today