### PR TITLE
NetNS: Allow full namespace path in constructor

### DIFF
--- a/pyroute2/netns/nslink.py
+++ b/pyroute2/netns/nslink.py
@@ -65,6 +65,7 @@ run `remove()`.
 '''
 
 import os
+import os.path
 import errno
 import fcntl
 import atexit
@@ -76,6 +77,7 @@ from pyroute2.config import MpProcess
 from pyroute2.netlink.rtnl.iprsocket import MarshalRtnl
 from pyroute2.iproute import IPRouteMixin
 from pyroute2.netns import setns
+from pyroute2.netns import setns_from_path
 from pyroute2.netns import remove
 from pyroute2.remote import Server
 from pyroute2.remote import RemoteSocket
@@ -128,7 +130,13 @@ def NetNServer(netns, cmdch, brdch, flags=os.O_CREAT):
     '''
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        nsfd = setns(netns, flags)
+        # Check if we wrepassed a namespace name or the namespace full path
+        # In the latter case flags will be ignored as it is assumed the
+        # namespace already exists
+        if os.path.isfile(netns):
+            nsfd = setns_from_path(netns)
+        else:
+            nsfd = setns(netns, flags)
     except OSError as e:
         cmdch.send({'stage': 'init',
                     'error': e})


### PR DESCRIPTION
If the netns argument to the NetNS constructor is the path of an
existing file, that is interpreted as the full namespace path, and
not appended to netns.NETNS_RUN_DIR.

This patch add a setns_from_path function to the netns module.
This function simply opens the namespace, perform the setns syscall,
and returns the file descriptor. In order to avoid code duplication
the setns function now calls setns_from_path

A test has been added to validate creating a NetNS object using the
path of an existing namespace.

Creating or deleting namespaces using a full path has not been
implemented as a part of this patch.