### PR TITLE
Added support for ipset.test

### DIFF
--- a/pyroute2/ipset.py
+++ b/pyroute2/ipset.py
@@ -27,6 +27,7 @@ from pyroute2.netlink.nfnetlink.ipset import IPSET_CMD_ADD
 from pyroute2.netlink.nfnetlink.ipset import IPSET_CMD_DEL
 from pyroute2.netlink.nfnetlink.ipset import IPSET_CMD_FLUSH
 from pyroute2.netlink.nfnetlink.ipset import IPSET_CMD_RENAME
+from pyroute2.netlink.nfnetlink.ipset import IPSET_CMD_TEST
 from pyroute2.netlink.nfnetlink.ipset import ipset_msg
 from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_COUNTERS
 from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_COMMENT
@@ -156,8 +157,8 @@ class IPSet(NetlinkSocket):
                 attrs += [['IPSET_ATTR_IFACE', e]]
         return attrs
 
-    def _add_delete(self, name, entry, family, cmd, exclusive, comment=None,
-                    timeout=None, etype="ip"):
+    def _add_delete_test(self, name, entry, family, cmd, exclusive, comment=None,
+                         timeout=None, etype="ip"):
         excl_flag = NLM_F_EXCL if exclusive else 0
 
         data_attrs = self._entry_to_data_attrs(entry, etype, family)
@@ -190,6 +191,13 @@ class IPSet(NetlinkSocket):
         '''
         return self._add_delete(name, entry, family, IPSET_CMD_DEL, exclusive,
                                 etype=etype)
+
+    def test(self, name, entry, family=socket.AF_INET, etype="ip"):
+        '''
+        Test if a member is part of an ipset
+        '''
+        return self._add_delete_test(name, entry, family, IPSET_CMD_TEST, False,
+                                     etype=etype)
 
     def swap(self, set_a, set_b):
         '''


### PR DESCRIPTION
Just a simple patch to add support for "test" in ipsets.

If no error, the entry exists in the set, otherwise a exception is raised with code 4103 (corresponding to "already exists" for add/delete, but means "wasn't found in the set" for test)