### PR TITLE
Sort addresses in IPaddrSet

### DIFF
--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -18,7 +18,6 @@ from pyroute2.ipdb.transactional import Transactional
 from pyroute2.ipdb.transactional import with_transaction
 from pyroute2.ipdb.transactional import SYNC_TIMEOUT
 from pyroute2.ipdb.linkedset import LinkedSet
-from pyroute2.ipdb.linkedset import IPaddrSet
 from pyroute2.ipdb.exceptions import CreateException
 from pyroute2.ipdb.exceptions import CommitException
 from pyroute2.ipdb.exceptions import PartialCommitException
@@ -120,7 +119,7 @@ class Interface(Transactional):
         with self._direct_state:
             for i in ('change', 'mask'):
                 del self[i]
-            self['ipaddr'] = IPaddrSet()
+            self['ipaddr'] = self.ipdb.init_ipaddr_set()
             self['ports'] = LinkedSet()
             self['vlans'] = LinkedSet()
             self['ipdb_priority'] = 0
@@ -1083,7 +1082,7 @@ class InterfacesDict(TransactionalBase):
             device = self[ifname] = self[index]
 
         if index not in self.ipdb.ipaddr:
-            self.ipdb.ipaddr[index] = IPaddrSet()
+            self.ipdb.ipaddr[index] = self.ipdb.init_ipaddr_set()
 
         if index not in self.ipdb.neighbours:
             self.ipdb.neighbours[index] = LinkedSet()
@@ -1147,7 +1146,7 @@ class AddressesDict(dict):
         # Reload addresses from the kernel.
         # (This is a workaround to reorder primary and secondary addresses.)
         for k in self.keys():
-            self[k] = IPaddrSet()
+            self[k] = self.ipdb.init_ipaddr_set()
         for msg in self.ipdb.nl.get_addr():
             self._new(msg)
         for idx in self.keys():

--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -1143,6 +1143,18 @@ class AddressesDict(dict):
         for msg in self.ipdb.nl.get_addr():
             self._new(msg)
 
+    def reload(self):
+        # Reload addresses from the kernel.
+        # (This is a workaround to reorder primary and secondary addresses.)
+        for k in self.keys():
+            self[k] = IPaddrSet()
+        for msg in self.ipdb.nl.get_addr():
+            self._new(msg)
+        for idx in self.keys():
+            iff = self.ipdb.interfaces[idx]
+            with iff._direct_state:
+                iff['ipaddr'] = self[idx]
+
     def _new(self, msg):
         if msg['family'] == socket.AF_INET:
             addr = msg.get_attr('IFA_LOCAL')

--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -536,6 +536,7 @@ from pyroute2.netlink.rtnl.ifinfmsg import ifinfmsg
 from pyroute2.ipdb import rule
 from pyroute2.ipdb import route
 from pyroute2.ipdb import interface
+from pyroute2.ipdb.linkedset import IPaddrSet, SortedIPaddrSet
 from pyroute2.ipdb.transactional import SYNC_TIMEOUT
 
 log = logging.getLogger(__name__)
@@ -580,8 +581,10 @@ class IPDB(object):
 
     def __init__(self, nl=None, mode='implicit',
                  restart_on_error=None, nl_async=None,
-                 ignore_rtables=None, callbacks=None):
+                 ignore_rtables=None, callbacks=None,
+                 sort_addresses=False):
         self.mode = mode
+        self.sort_addresses = sort_addresses
         self._event_map = {}
         self._deferred = {}
         self._loaded = set()
@@ -990,3 +993,9 @@ class IPDB(object):
                                 pass
                             if len(self._cb_threads.get(cuid, ())) == 0:
                                 del self._cb_threads[cuid]
+
+    def init_ipaddr_set(self):
+        if self.sort_addresses:
+            return SortedIPaddrSet()
+        else:
+            return IPaddrSet()


### PR DESCRIPTION
Primary and secondary addresses depend on the order in which they are added to an interface [1] .  This commit makes pyroute2 add IP addresses in the same order Interface.add_ip is called. This is achieved by changing LinkedSet.raw from a plain dict to an OrderedDict and reimplementing set set operators in IPaddrSet. The `reload` function reloads all addresses from the kernel.  This also lets `pyroute2` reload the order primary and secondary addresses on interfaces. (More details in the commit messages.)

 [1] iproute2 docs: http://baturin.org/docs/iproute2/#Notes
