### PR TITLE
support NETLINK_LISTEN_ALL_NSID netlink option

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -561,6 +561,8 @@ NETLINK_NO_ENOBUFS = 5
 NETLINK_RX_RING = 6
 NETLINK_TX_RING = 7
 
+NETLINK_LISTEN_ALL_NSID = 8
+
 clean_cbs = {}
 
 # Cached results for some struct operations.

--- a/pyroute2/netlink/rtnl/iprsocket.py
+++ b/pyroute2/netlink/rtnl/iprsocket.py
@@ -21,8 +21,9 @@ else:
 
 class IPRSocketMixin(object):
 
-    def __init__(self, fileno=None):
-        super(IPRSocketMixin, self).__init__(NETLINK_ROUTE, fileno=fileno)
+    def __init__(self, fileno=None, all_ns=False):
+        super(IPRSocketMixin, self).__init__(NETLINK_ROUTE, fileno=fileno,
+                                             all_ns=all_ns)
         self.marshal = MarshalRtnl()
         self._s_channel = None
         send_ns = Namespace(self, {'addr_pool': AddrPool(0x10000, 0x1ffff),


### PR DESCRIPTION
From netlink documentation:
NETLINK_LISTEN_ALL_NSID (since Linux 4.2)
When set, this socket will receive netlink notifications from all network namespaces that have an nsid assigned into the network namespace where the socket has been opened.  The nsid is sent to user space via an ancillary data.