### PR TITLE
Bugfix: Fix HTB QDisc Generation With Default Arguments

### DIFF
--- a/pyroute2/iproute.py
+++ b/pyroute2/iproute.py
@@ -1459,7 +1459,7 @@ class IPRouteMixin(object):
             msg['parent'] = kwarg.get('parent', TC_H_ROOT)
 
         if kind is not None:
-            msg['attrs'] = [['TCA_KIND', kind]]
+            msg['attrs'].append(['TCA_KIND', kind])
         if opts is not None:
             msg['attrs'].append(['TCA_OPTIONS', opts])
         return self.nlm_request(msg, msg_type=command, msg_flags=flags)

--- a/pyroute2/netlink/rtnl/tcmsg/sched_htb.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_htb.py
@@ -121,6 +121,7 @@ def get_parameters(kwarg):
                                         'rate2quantum': rate2quantum,
                                         'version': version}]]}
 
+
 def fix_msg(msg, kwarg):
     if not kwarg:
         opts = get_parameters({})

--- a/pyroute2/netlink/rtnl/tcmsg/sched_htb.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_htb.py
@@ -121,6 +121,11 @@ def get_parameters(kwarg):
                                         'rate2quantum': rate2quantum,
                                         'version': version}]]}
 
+def fix_msg(msg, kwarg):
+    if not kwarg:
+        opts = get_parameters({})
+        msg['attrs'].append(['TCA_OPTIONS', opts])
+
 
 class stats(nla):
     fields = (('lends', 'I'),


### PR DESCRIPTION
When we call `tc` function for creating the HTB QDisc with NO kwargs,
the kernel will return error 22 (invalid argument):

	 ip.tc("add", "htb", eth0, 0x10000)
	 pyroute2.netlink.exceptions.NetlinkError: (22, 'Invalid argument')

As you can see by calling the `tc` function without any additional
arguments (we only defined `command`, `kind`, `index` and `handle`
arguments) the module will raise `NetlinkError`; reason: according to
'net/sched/sch_htb.c' of linux kernel source code, to create a HTB
QDisc we also need to define `direct_pkts`, `rate2quantum` and
`defcls` which is not defined by default (the function
`get_parameters` is responsible for providing these default arguments
which WON'T be called unless we have at least ONE argument in kwargs.

with '#' will be ignored, and an empty message aborts the commit.  #
On branch htb_default_atrr_bug # Changes to be committed: # modified:
pyroute2/iproute.py # modified:
pyroute2/netlink/rtnl/tcmsg/sched_htb.py #