### PR TITLE
ipdb/interfaces: force address load for vlan interfaces

### DIFF
--- a/examples/custom_socket_base.py
+++ b/examples/custom_socket_base.py
@@ -52,6 +52,7 @@ class SocketWrapper(object):
     def dup(self):
         return self.__class__(_sock=self._sock.dup())
 
+
 config.SocketBase = SocketWrapper
 
 print(netns.listnetns())

--- a/examples/generic/netl.py
+++ b/examples/generic/netl.py
@@ -34,6 +34,7 @@ class Rlink(GenericNetlinkSocket):
                                msg_flags=NLM_F_REQUEST)[0]
         return ret.get_attr('RLINK_ATTR_DATA')
 
+
 try:
     # create protocol instance
     rlink = Rlink()

--- a/examples/ipdb_autobr.py
+++ b/examples/ipdb_autobr.py
@@ -38,6 +38,7 @@ def cb(ipdb, msg, action):
         except Exception:
             pass
 
+
 # create IPDB instance
 with IPDB() as ip:
     # create watchdogs

--- a/examples/ipdb_precb.py
+++ b/examples/ipdb_precb.py
@@ -18,6 +18,7 @@ def cb(ipdb, msg, action):
     if action == 'RTM_NEWLINK':
         msg['flags'] = 1234
 
+
 # create IPDB instance
 ip = IPDB()
 # register "pre" callback

--- a/pyroute2/__init__.py
+++ b/pyroute2/__init__.py
@@ -146,6 +146,8 @@ class __common(object):
         log.warning('module pyroute2.ipdb.common is deprecated, '
                     'use pyroute2.ipdb.exceptions instead')
         return getattr(globals()['ipdb'].exceptions, key)
+
+
 globals()['ipdb'].common = __common()
 
 __all__.extend([x.__name__ for x in exceptions])

--- a/pyroute2/ipdb/interface.py
+++ b/pyroute2/ipdb/interface.py
@@ -815,7 +815,7 @@ class Interface(Transactional):
                 #
                 # FIXME: probably, we should handle other
                 # types as well
-                if self['kind'] in ('bond', 'bridge', 'veth'):
+                if self['kind'] in ('bond', 'bridge', 'veth', 'vlan'):
                     for addr in self.nl.get_addr(family=socket.AF_INET6):
                         self.ipdb.ipaddr._new(addr)
 

--- a/pyroute2/ipdb/route.py
+++ b/pyroute2/ipdb/route.py
@@ -121,6 +121,7 @@ class WatchdogKey(dict):
                                          'gateway',
                                          'table') and x[1]])
 
+
 # Universal route key
 RouteKey = namedtuple('RouteKey',
                       ('dst',

--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -415,6 +415,7 @@ _de = NetlinkDecodeError  #
 class NotInitialized(Exception):
     pass
 
+
 _letters = re.compile('[A-Za-z]')
 _fmt_letters = re.compile('[^!><@=][!><@=]')
 

--- a/pyroute2/netlink/diag/__init__.py
+++ b/pyroute2/netlink/diag/__init__.py
@@ -37,6 +37,7 @@ class sock_diag_req(nlmsg):
     fields = (('sdiag_family', 'B'),
               ('sdiag_protocol', 'B'))
 
+
 UDIAG_SHOW_NAME = 0x01
 UDIAG_SHOW_VFS = 0x02
 UDIAG_SHOW_PEER = 0x04


### PR DESCRIPTION
`vlan` interfaces, like `bond`, `bridge` & `veth` requires a forced address reload