### PR TITLE
let users choose RTNL groups IPDB listens to

### DIFF
--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -531,7 +531,7 @@ import threading
 from pyroute2 import config
 from pyroute2.common import uuid32
 from pyroute2.iproute import IPRoute
-from pyroute2.netlink.rtnl import RTM_GETLINK
+from pyroute2.netlink.rtnl import RTM_GETLINK, RTNL_GROUPS
 from pyroute2.netlink.rtnl.ifinfmsg import ifinfmsg
 from pyroute2.ipdb import rule
 from pyroute2.ipdb import route
@@ -581,6 +581,7 @@ class IPDB(object):
 
     def __init__(self, nl=None, mode='implicit',
                  restart_on_error=None, nl_async=None,
+                 nl_bind_groups=RTNL_GROUPS,
                  ignore_rtables=None, callbacks=None,
                  sort_addresses=False):
         self.mode = mode
@@ -593,6 +594,7 @@ class IPDB(object):
         self._nl_async = config.ipdb_nl_async if nl_async is None else True
         self.mnl = None
         self.nl = nl
+        self.nl_bind_groups = nl_bind_groups
         self._plugins = [interface, route, rule]
         if isinstance(ignore_rtables, int):
             self._ignore_rtables = [ignore_rtables, ]
@@ -659,7 +661,7 @@ class IPDB(object):
         # setup monitoring socket
         self.mnl = self.nl.clone()
         try:
-            self.mnl.bind(async=self._nl_async)
+            self.mnl.bind(groups=self.nl_bind_groups, async=self._nl_async)
         except:
             self.mnl.close()
             if self._nl_own is None:


### PR DESCRIPTION
IPDB listens to all netlink updates by default.  Some applications
might not require information about all netlink-managed entities.
Filtering the messages that the kernel sends IPDB alleviates CPU use
and might prevent buffer overflow errors that happen during netlink
broadcast storms.

Our use case is that we observed buffer overflows when using IPDB to manage IP addresses and IP rules on a server having a large number of full routing tables. To test these changes (and make the problem reproducible), I created a [C program to create netlink storms][1] and used the simple script below. Without filtering route messages, it causes buffer overflows on pyroute instantly, in 100% of the tests I ran. Filtering route updates, no overflows were observed.

 [1]: https://github.com/cunha/storm-netlink/blob/master/storm.c

``` {Python}
#!/usr/bin/python3

import time
import sys
from pyroute2 import IPDB
# import pyroute2.netlink.rtnl as rtnl


# GROUPS = rtnl.RTNL_GROUPS
# GROUPS &= ~rtnl.RTNLGRP_IPV4_ROUTE
# GROUPS &= ~rtnl.RTNLGRP_IPV6_ROUTE


def test_routes():
    while True:
        # with IPDB(nl_bind_groups=GROUPS, nl_async=True) as ipdb:
        with IPDB(nl_async=True) as ipdb:
            i = len(list(r for r in ipdb.routes))
            sys.stdout.write('%d\n' % i)
            i = len(list(r for r in ipdb.routes.tables[152]))
            sys.stdout.write('%d\n' % i)
        time.sleep(1)


if __name__ == '__main__':
    sys.exit(test_routes())
```