### PR TITLE
Fix machine name and syscall number of aarch64(arm 64-bit)

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -90,8 +90,8 @@ __NR = {'x86_': {'64bit': 308},
         'i686': {'32bit': 346},
         'mips': {'32bit': 4344,
                  '64bit': 5303},  # FIXME: NABI32?
-        'armv': {'32bit': 375,
-                 '64bit': 375}}  # FIXME: EABI vs. OABI?
+        'armv': {'32bit': 375},
+        'aarc': {'64bit': 268}}  # FIXME: EABI vs. OABI?
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 
 CLONE_NEWNET = 0x40000000


### PR DESCRIPTION
 import os
os.uname()
         ('Linux', 'Mustang0', '4.9.0-rc3-00011-g13c5a1f', '#4 SMP PREEMPT Fri Dec 9 08:47:26 CST 2016', 'aarch64')

os.uname()[4]
       'aarch64'`

Signed-off-by: Zhiyi Sun <zhiyisun@gmail.com>