### PR TITLE
redhat packaging: bump version to 0.4.13

### DIFF
--- a/packages/RedHat/python-pyroute2.spec
+++ b/packages/RedHat/python-pyroute2.spec
@@ -4,7 +4,7 @@
 %{!?python3_pkgversion:%global python3_pkgversion 3}
 
 Name: python-%{srcname}
-Version: 0.4.10
+Version: 0.4.13
 Release: 1%{?dist}
 Summary: %{sum}
 License: GPLv2+
@@ -60,6 +60,18 @@ IPQ.
 %{python3_sitelib}/%{srcname}*
 
 %changelog
+* Tue Mar  7 2017 Antoni S. Puimedon <antonisp@celebdor.com> 0.4.13-1
+- upgrade to 0.4.13
+- ipset hash:mac support
+- ipset: hash:mac support
+- ipset: list:set support
+- ifinfmsg: allow absolute/relative paths in the net_ns_fd NLA
+- ipdb: #322 -- IPv6 updates on interfaces in DOWN state
+- rtnl: #284 -- support vlan_flags
+- ipdb: #307 -- fix IPv6 routes management
+= ipdb: #311 -- vlan interfaces address loading
+- iprsocket: #305 -- support NETLINK_LISTEN_ALL_NSID
+
 * Fri Oct 14 2016 Peter V. Saveliev <peter@svinota.eu> 0.4.10-1
 - devlink fd leak fix
 


### PR DESCRIPTION
It it time to publish 0.4.13 in EL and fedora

Signed-off-by: Antoni Segura Puimedon <antonisp@celebdor.com>