### PR TITLE
Fix tc u32 action stats

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/cls_u32.py
+++ b/pyroute2/netlink/rtnl/tcmsg/cls_u32.py
@@ -110,10 +110,9 @@ class options(nla, nla_plus_police):
                        ('TCA_ACT_KIND', 'asciiz'),
                        ('TCA_ACT_OPTIONS', 'get_act_options'),
                        ('TCA_ACT_INDEX', 'hex'),
-                       ('TCA_ACT_STATS', 'get_stats2'))
+                       ('TCA_ACT_STATS', 'stats2'))
 
-            def get_stats2(self, *argv, **kwarg):
-                return stats2
+            stats2 = stats2
 
     class u32_sel(nla):
         fields = (('flags', 'B'),


### PR DESCRIPTION
Hello,
I noticed the u32 filter returned the stats2 class instead of an instance for its `TCA_ACT_STATS` member. As a result, it crashed when trying to parse attached action stats.

I fixed it in the code and wrote a test for it. If you want to reproduce, just run the test on a repository that hasn't got the fix yet.