### PR TITLE
logging: fix spurious warnings when no logging handler is configured

### DIFF
--- a/pyroute2/__init__.py
+++ b/pyroute2/__init__.py
@@ -19,6 +19,10 @@ from pyroute2.netlink.exceptions import \
     NetlinkDecodeError
 
 log = logging.getLogger(__name__)
+# Add a NullHandler to the library's top-level logger to avoid complaints
+# on logging calls when no handler is configured.
+# see https://docs.python.org/2/howto/logging.html#library-config
+log.addHandler(logging.NullHandler())
 
 try:
     # probe, if the bytearray can be used in struct.unpack_from()

--- a/pyroute2/__init__.py
+++ b/pyroute2/__init__.py
@@ -22,7 +22,8 @@ log = logging.getLogger(__name__)
 # Add a NullHandler to the library's top-level logger to avoid complaints
 # on logging calls when no handler is configured.
 # see https://docs.python.org/2/howto/logging.html#library-config
-log.addHandler(logging.NullHandler())
+if sys.version_info >= (2, 7):  # This is only available from 2.7 onwards
+    log.addHandler(logging.NullHandler())
 
 try:
     # probe, if the bytearray can be used in struct.unpack_from()


### PR DESCRIPTION
Hello,
This adds a `logging.NullHandler` handler to the library's top-level logger, as recommended by [the official Python documentation](https://docs.python.org/2/howto/logging.html#library-config) for libraries.

This fixes an issue that had no satisfactory solution until now:
- We either add a regular log handler, which should not be done in a library as it can cause duplicate logs (issue #255)
- Or we don't, but this produces warnings on logging calls when no handler has been configured by the library user (issue #270)

This is not compatible with Python 2.6 but I can amend the pull request if necessary.