### PR TITLE
add the tc connmark action

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/act_connmark.py
+++ b/pyroute2/netlink/rtnl/tcmsg/act_connmark.py
@@ -1,0 +1,45 @@
+from pyroute2.netlink import nla
+from pyroute2.netlink import NLA_F_NESTED
+from pyroute2.netlink.rtnl.tcmsg.common import tc_actions
+
+"""
+connmark - netfilter connmark retriever action
+see tc-connmark(8)
+
+This filter restores the connection mark into the packet mark.
+Connection marks are typically handled by the CONNMARK iptables module.
+See iptables-extensions(8).
+
+There is no mandatory parameter, but you can specify the action, which defaults
+to 'pipe', and the conntrack zone (see the manual).
+"""
+
+
+class options(nla):
+    nla_flags = NLA_F_NESTED
+    nla_map = (('TCA_CONNMARK_UNSPEC', 'none'),
+               ('TCA_CONNMARK_PARMS', 'tca_connmark_parms'),
+               ('TCA_CONNMARK_TM', 'none'),
+               )
+
+    class tca_connmark_parms(nla):
+        fields = (('index', 'I'),
+                  ('capab', 'I'),
+                  ('action', 'i'),
+                  ('refcnt', 'i'),
+                  ('bindcnt', 'i'),
+                  ('zone', 'H'),
+                  ('__padding', 'H'),  # XXX is there a better way to do this ?
+                  )
+
+
+def get_parameters(kwarg):
+    ret = {'attrs': []}
+
+    parms = {
+        'action': tc_actions[kwarg.get('action', 'pipe')],
+        'zone': kwarg.get('zone', 0)
+    }
+
+    ret['attrs'].append(['TCA_CONNMARK_PARMS', parms])
+    return ret

--- a/pyroute2/netlink/rtnl/tcmsg/common_act.py
+++ b/pyroute2/netlink/rtnl/tcmsg/common_act.py
@@ -2,11 +2,13 @@ from pyroute2.netlink.rtnl.tcmsg import act_gact
 from pyroute2.netlink.rtnl.tcmsg import act_bpf
 from pyroute2.netlink.rtnl.tcmsg import act_police
 from pyroute2.netlink.rtnl.tcmsg import act_mirred
+from pyroute2.netlink.rtnl.tcmsg import act_connmark
 
 plugins = {'gact': act_gact,
            'bpf': act_bpf,
            'police': act_police,
            'mirred': act_mirred,
+           'connmark': act_connmark,
            }
 
 


### PR DESCRIPTION
Hello,
I added the tc connmark action + a test for it.

I wasn't quite sure about the proper way to handle the padding in `TCA_CONNMARK_PARMS`, this looks fine to me but tell me if there's a better way. 

As for the test, this is a quite recent addition to the kernel as far as I know, so I wrapped it in a `skip_if_not_supported`.