### PR TITLE
Tc mirred action fix

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/act_mirred.py
+++ b/pyroute2/netlink/rtnl/tcmsg/act_mirred.py
@@ -1,5 +1,6 @@
 from pyroute2.netlink import nla
 from pyroute2.netlink import NLA_F_NESTED
+from pyroute2.netlink.rtnl.tcmsg.common import tc_actions
 """
 Mirred - mirror/redirect action
 see tc-mirred(8)
@@ -48,6 +49,12 @@ def get_parameters(kwarg):
 
     if 'index' in kwarg:
         parms['index'] = int(kwarg['index'])
+
+    # From m_mirred.c
+    if kwarg['action'] == 'redirect':
+        parms['action'] = tc_actions['stolen']
+    else:  # mirror
+        parms['action'] = tc_actions['pipe']
 
     ret['attrs'].append(['TCA_MIRRED_PARMS', parms])
     return ret

--- a/pyroute2/netlink/rtnl/tcmsg/common.py
+++ b/pyroute2/netlink/rtnl/tcmsg/common.py
@@ -177,9 +177,15 @@ def get_rate_parameters(kwarg):
 
 tc_actions = {'unspec': -1,     # TC_ACT_UNSPEC
               'ok': 0,          # TC_ACT_OK
+              'reclassify': 1,  # TC_ACT_RECLASSIFY
               'shot': 2,        # TC_ACT_SHOT
               'drop': 2,        # TC_ACT_SHOT
-              'pipe': 3}        # TC_ACT_PIPE
+              'pipe': 3,        # TC_ACT_PIPE
+              'stolen': 4,      # TC_ACT_STOLEN
+              'queued': 5,      # TC_ACT_QUEUED
+              'repeat': 6,      # TC_ACT_REPEAT
+              'redirect': 7,    # TC_ACT_REDIRECT
+              }
 
 
 class nla_plus_rtab(nla):


### PR DESCRIPTION
This fixes an oversight in the mirred action: I forgot to properly set the action type which led to unexpected behavior such as duplicate packets in redirect mode.

I added a few action types to `pyroute2.netlink.rtnl.tcmsg.common.tc_actions` as well because there was a missing action I needed.