### PR TITLE
Try to reduce memory usage in case of messages containing lots of similiar entries

### DIFF
--- a/pyroute2/netlink/rtnl/ndmsg.py
+++ b/pyroute2/netlink/rtnl/ndmsg.py
@@ -64,6 +64,9 @@ class ndmsg(nlmsg):
             __u32         ndm_refcnt;
         };
     '''
+
+    __slots__ = ()
+
     prefix = 'NDA_'
 
     fields = (('family', 'B'),
@@ -95,6 +98,9 @@ class ndmsg(nlmsg):
                ('NDA_MASTER', 'uint32'))
 
     class cacheinfo(nla):
+
+        __slots__ = ()
+
         fields = (('ndm_confirmed', 'I'),
                   ('ndm_used', 'I'),
                   ('ndm_updated', 'I'),

--- a/pyroute2/netlink/rtnl/ndtmsg.py
+++ b/pyroute2/netlink/rtnl/ndtmsg.py
@@ -7,6 +7,9 @@ class ndtmsg(nlmsg):
     '''
     Neighbour table message
     '''
+
+    __slots__ = ()
+
     fields = (('family', 'B'),
               ('__pad', '3x'))
 
@@ -21,6 +24,9 @@ class ndtmsg(nlmsg):
                ('NDTA_GC_INTERVAL', 'uint64'))
 
     class config(nla):
+
+        __slots__ = ()
+
         fields = (('key_len', 'H'),
                   ('entry_size', 'H'),
                   ('entries', 'I'),
@@ -32,6 +38,9 @@ class ndtmsg(nlmsg):
                   ('proxy_qlen', 'I'))
 
     class stats(nla):
+
+        __slots__ = ()
+
         fields = (('allocs', 'Q'),
                   ('destroys', 'Q'),
                   ('hash_grows', 'Q'),
@@ -44,6 +53,9 @@ class ndtmsg(nlmsg):
                   ('forced_gc_runs', 'Q'))
 
     class parms(nla):
+
+        __slots__ = ()
+
         nla_map = (('NDTPA_UNSPEC', 'none'),
                    ('NDTPA_IFINDEX', 'uint32'),
                    ('NDTPA_REFCNT', 'uint32'),

--- a/pyroute2/netlink/rtnl/req.py
+++ b/pyroute2/netlink/rtnl/req.py
@@ -321,7 +321,7 @@ class IPLinkRequest(IPRequest):
         # load specific NLA names
         cls = ifinfmsg.ifinfo.data_map.get(self.kind, None)
         if cls is not None:
-            prefix = getattr(cls, 'prefix', 'IFLA_')
+            prefix = cls.prefix or 'IFLA_'
             for nla, _ in cls.nla_map:
                 self.specific[nla[len(prefix):].lower()] = nla
 

--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -59,6 +59,9 @@ class rtmsg_base(nlflags):
             unsigned int  rtm_flags;
         };
     '''
+
+    __slots__ = ()
+
     prefix = 'RTA_'
 
     fields = (('family', 'B'),
@@ -101,15 +104,24 @@ class rtmsg_base(nlflags):
         return self.mpls_encap_info
 
     class mpls_encap_info(nla):
+
+        __slots__ = ()
+
         nla_map = (('MPLS_IPTUNNEL_UNSPEC', 'none'),
                    ('MPLS_IPTUNNEL_DST', 'mpls_target'))
 
     class rta_mfc_stats(nla):
+
+        __slots__ = ()
+
         fields = (('mfcs_packets', 'uint64'),
                   ('mfcs_bytes', 'uint64'),
                   ('mfcs_wrong_if', 'uint64'))
 
     class metrics(nla):
+
+        __slots__ = ()
+
         prefix = 'RTAX_'
         nla_map = (('RTAX_UNSPEC', 'none'),
                    ('RTAX_LOCK', 'uint32'),
@@ -133,6 +145,9 @@ class rtmsg_base(nlflags):
         return nh
 
     class rtvia(nla):
+
+        __slots__ = ()
+
         fields = (('value', 's'), )
 
         def encode(self):
@@ -158,6 +173,9 @@ class rtmsg_base(nlflags):
             self.value = {'family': family, 'addr': addr}
 
     class cacheinfo(nla):
+
+        __slots__ = ()
+
         fields = (('rta_clntref', 'I'),
                   ('rta_lastuse', 'I'),
                   ('rta_expires', 'i'),
@@ -169,6 +187,8 @@ class rtmsg_base(nlflags):
 
 
 class rtmsg(rtmsg_base, nlmsg):
+
+    __slots__ = ()
 
     def encode(self):
         if self.get('family') == AF_MPLS:
@@ -188,6 +208,9 @@ class rtmsg(rtmsg_base, nlmsg):
 
 
 class nh(rtmsg_base, nla):
+
+    __slots__ = ()
+
     is_nla = False
     cell_header = (('length', 'H'), )
     fields = (('flags', 'B'),

--- a/pyroute2/netlink/rtnl/tcmsg/common.py
+++ b/pyroute2/netlink/rtnl/tcmsg/common.py
@@ -240,6 +240,7 @@ class nla_plus_rtab(nla):
 
     class rtab(nla):
         fields = (('value', 's'), )
+        own_parent = True
 
         def encode(self):
             parms = self.parent.get_encoded('TCA_TBF_PARMS') or \


### PR DESCRIPTION
This patch reduce memory consumption for some workloads like reading neighbours on hosts with big NDP tables (~10k entries):
```
import socket
from pyroute2 import IPRoute
IPRoute().get_neighbours(socket.AF_INET6)
```
Peak memory usage descreased from 70MB to 30MB, see https://gist.github.com/blackwithwhite666/971bf9a9f8ff1905be5c4cc15decb5b2 for details.

Another important change (and this may change API provided by nlmsg_base): parent is weakref by default. Because of it no reference cycles created so there is no need to track those objects by GC (see graphs from previous link).

jfyi: some tests fails on master branch for me, https://gist.github.com/blackwithwhite666/3d6d6ecd8678c3db05b5c487f1b9315c, i don't find what's the problem with them.