### PR TITLE
tc: allow to change or replace a qdisc

### DIFF
--- a/pyroute2/iproute.py
+++ b/pyroute2/iproute.py
@@ -1437,6 +1437,8 @@ class IPRouteMixin(object):
                     'del': (RTM_DELQDISC, flags_make),
                     'remove': (RTM_DELQDISC, flags_make),
                     'delete': (RTM_DELQDISC, flags_make),
+                    'change': (RTM_NEWQDISC, flags_change),
+                    'replace': (RTM_NEWQDISC, flags_replace),
                     'add-class': (RTM_NEWTCLASS, flags_make),
                     'del-class': (RTM_DELTCLASS, flags_make),
                     'change-class': (RTM_NEWTCLASS, flags_change),


### PR DESCRIPTION
Note that I am a bit puzzled that the flags are not the same than for `tc`, but this works. In `tc/qdisc.c`, there is:

```c
	if (matches(*argv, "add") == 0)
		return tc_qdisc_modify(RTM_NEWQDISC, NLM_F_EXCL|NLM_F_CREATE, argc-1, argv+1);
	if (matches(*argv, "change") == 0)
		return tc_qdisc_modify(RTM_NEWQDISC, 0, argc-1, argv+1);
	if (matches(*argv, "replace") == 0)
		return tc_qdisc_modify(RTM_NEWQDISC, NLM_F_CREATE|NLM_F_REPLACE, argc-1, argv+1);
```