### PR TITLE
Add check for macvlan in set_specific

### DIFF
--- a/pyroute2/netlink/rtnl/req.py
+++ b/pyroute2/netlink/rtnl/req.py
@@ -402,6 +402,8 @@ class IPLinkRequest(IPRequest):
                 nla = ['IFTUN_MODE', value]
             elif self.kind == 'bond':
                 nla = ['IFLA_BOND_MODE', value]
+            elif self.kind == 'macvlan':
+                nla = ['IFLA_MACVLAN_MODE', value]
             self.info_data.append(nla)
             return True
 


### PR DESCRIPTION
Fixes #374

Looking at the code, this looks like what's missing, but I haven't had a chance to test it yet. I can't do it currently as you can't make mavlans on tunnel interfaces and I'm currently on a VPN to work and on a laptop.

But this is breaking production stuff for me, so I think I'm just going to have to hot patch it and get back to you 😉 