### PR TITLE
use stdlib for plugins

### DIFF
--- a/pyroute2/config/__init__.py
+++ b/pyroute2/config/__init__.py
@@ -23,6 +23,4 @@ machine = platform.machine()
 arch = platform.architecture()[0]
 kernel = LooseVersion(uname[2]).version[:3]
 
-# IFLA_INFO_DATA plugin system prototype
-_absdir = os.path.dirname(os.path.abspath(common.__file__))
-data_plugins_path = [_absdir + '/netlink/rtnl/ifinfmsg/plugins', ]
+data_plugins_pkgs = []


### PR DESCRIPTION
In order to allow for things like Pyinstaller, it is best to use a more
standard approach to plugin support.

Signed-off-by: Antoni Segura Puimedon <antonisp@celebdor.com>