### PR TITLE
netns: ppc64 arch reference fixed

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -96,7 +96,8 @@ __NR = {'x86_': {'64bit': 308},
         'mips': {'32bit': 4344,
                  '64bit': 5303},  # FIXME: NABI32?
         'armv': {'32bit': 375},
-        'aarc': {'64bit': 268}}  # FIXME: EABI vs. OABI?
+        'aarc': {'64bit': 268},  # FIXME: EABI vs. OABI?
+        'ppc6': {'64bit': 350}}
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 
 CLONE_NEWNET = 0x40000000


### PR DESCRIPTION
With default value 308, power systems fails to create NetNS object. This patch fixes it with proper value for ppc64* arch.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>