### PR TITLE
Correctly parse IFLA_VLAN_PROTOCOL in IPDB interface

### DIFF
--- a/pyroute2/ipdb/interfaces.py
+++ b/pyroute2/ipdb/interfaces.py
@@ -103,6 +103,7 @@ class Interface(Transactional):
     _fields.append('kind')
     _fields.append('peer')
     _fields.append('vlan_id')
+    _fields.append('vlan_protocol')
     _fields.append('bond_mode')
     _fields.extend(_get_data_fields())
     _fields.extend(_virtual_fields)
@@ -308,6 +309,7 @@ class Interface(Transactional):
                     if kind == 'vlan':
                         data = linkinfo.get_attr('IFLA_INFO_DATA')
                         self['vlan_id'] = data.get_attr('IFLA_VLAN_ID')
+                        self['vlan_protocol'] = data.get_attr('IFLA_VLAN_PROTOCOL')
                         self['vlan_flags'] = data\
                             .get_attr('IFLA_VLAN_FLAGS', {})\
                             .get('flags', 0)


### PR DESCRIPTION
In issue https://github.com/svinota/pyroute2/issues/361 the example file qinq.zip works with IPRoute.

When trying the same with IPDB, parsing the result when committing an interface with vlan_protocol fails:

```
Traceback (most recent call last):
  File "qinq.py", line 9, in <module>
    ipdb.create(kind="vlan", ifname="qtest.50", link=hidx, vlan_id=50, vlan_protocol=0x88a8).commit()
  File "/usr/local/lib/python2.7/dist-packages/pyroute2/pyroute2/ipdb/interfaces.py", line 1060, in commit
    raise error
pyroute2.ipdb.exceptions.CommitException: target vlan_protocol is not set
```
This fixes the issue for me.

This is the modified qinq.py:
```python

from pyroute2 import IPDB

ipdb = IPDB()
# create host dummy
ipdb.create(kind="dummy", ifname="qtest").commit()
hidx = ipdb.interfaces['qtest']

# create 802.1ad s-vlan interface (external tag)
ipdb.create(kind="vlan", ifname="qtest.50", link=hidx, vlan_id=50, vlan_protocol=0x88a8).commit()

# create 802.1q c-vlan interface (internal tag)
ipdb.create(kind="vlan", ifname="qtest.50.120", link=hidx, vlan_id=120, vlan_protocol=0x8100).commit()

# print the links
for link in (ipdb.interfaces['qtest.50'], ipdb.interfaces['qtest.50.120']):
    print(link.ifname)
    print("\t%s" % (link.vlan_protocol))


# cleanup
hidx.remove().commit()
```
