### PR TITLE
IPDB: register_callback: check if `mode` is valid

### DIFF
--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -975,6 +975,8 @@ class IPDB(object):
             self._post_callbacks[safe.uuid] = safe
         elif mode == 'pre':
             self._pre_callbacks[safe.uuid] = safe
+        else:
+            raise KeyError('Unknown callback mode')
         return safe.uuid
 
     def unregister_callback(self, cuid, mode='post'):


### PR DESCRIPTION
In `register_callback()` check if `mode` is one of 'pre' or 'post'
and raise exception if it is not, the same way as it is already done
in `unregister_callback()`.

Signed-off-by: Eugene Crosser <crosser@average.org>