### PR TITLE
ipdb.interfaces: Fix AttributeError

### DIFF
--- a/pyroute2/ipdb/interfaces.py
+++ b/pyroute2/ipdb/interfaces.py
@@ -1237,7 +1237,7 @@ class InterfacesDict(Dotkeys):
             if old_index in self.ipdb.neighbours:
                 self.ipdb.neighbours[index] = \
                     self.ipdb.neighbours[old_index]
-                del self.neighbours[old_index]
+                del self.ipdb.neighbours[old_index]
         else:
             # scenario #3, interface rename
             # scenario #4, assume rename


### PR DESCRIPTION
I found an issue in https://github.com/svinota/pyroute2/blob/master/pyroute2/ipdb/interfaces.py#L1240 which causes following:

```
Exception in thread IPDB event loop:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib/python2.7/site-packages/pyroute2/ipdb/main.py", line 1252, in serve_forever
    func(msg)
  File "/usr/lib/python2.7/site-packages/pyroute2/ipdb/interfaces.py", line 1244, in _new
    del self.neighbours[old_index]
  File "/usr/lib/python2.7/site-packages/pyroute2/common.py", line 202, in __getattribute__
    raise e
AttributeError: 'InterfacesDict' object has no attribute 'neighbours'
```