### PR TITLE
Adding support for the TC Vlan action

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/act_vlan.py
+++ b/pyroute2/netlink/rtnl/tcmsg/act_vlan.py
@@ -1,0 +1,42 @@
+from pyroute2.netlink import nla
+from pyroute2.netlink.rtnl.tcmsg.common import tc_actions
+from socket import htons
+
+v_actions = {'pop': 1,
+             'push': 2,
+             'modify': 3}
+
+
+class options(nla):
+    nla_map = (('TCA_VLAN_UNSPEC','none'),
+               ('TCA_VLAN_TM','none'),
+               ('TCA_VLAN_PARMS','tca_vlan_parms'),
+               ('TCA_VLAN_PUSH_VLAN_ID','uint16'),
+               ('TCA_VLAN_PUSH_VLAN_PROTOCOL','uint16'),
+               ('TCA_VLAN_PAD','none'),
+               ('TCA_VLAN_PUSH_VLAN_PRIORITY','uint8'))
+
+    class tca_vlan_parms(nla):
+        fields = (('index', 'I'),
+                  ('capab', 'I'),
+                  ('action', 'i'),
+                  ('refcnt', 'i'),
+                  ('bindcnt', 'i'),
+                  ('v_action','i'),)
+
+
+def get_parameters(kwarg):
+    ret = {'attrs': []}
+    parms = { 'v_action': v_actions[kwarg['v_action']]}
+    parms['action'] = tc_actions[kwarg.get('action', 'pipe')]
+    ret['attrs'].append(['TCA_VLAN_PARMS', parms])
+    #Vlan id compulsory for "push" and "modify"
+    if kwarg['v_action'] in ['push','modify']:
+        ret['attrs'].append(['TCA_VLAN_PUSH_VLAN_ID', kwarg['id']])
+    if 'priority' in kwarg:
+        ret['attrs'].append(['TCA_VLAN_PUSH_VLAN_PRIORITY', kwarg['priority']])
+    if kwarg.get('protocol','802.1Q') == '802.1ad':
+        ret['attrs'].append(['TCA_VLAN_PUSH_VLAN_PROTOCOL', htons(0x88a8)])
+    else:
+        ret['attrs'].append(['TCA_VLAN_PUSH_VLAN_PROTOCOL', htons(0x8100)])
+    return ret

--- a/pyroute2/netlink/rtnl/tcmsg/common_act.py
+++ b/pyroute2/netlink/rtnl/tcmsg/common_act.py
@@ -3,12 +3,14 @@ from pyroute2.netlink.rtnl.tcmsg import act_bpf
 from pyroute2.netlink.rtnl.tcmsg import act_police
 from pyroute2.netlink.rtnl.tcmsg import act_mirred
 from pyroute2.netlink.rtnl.tcmsg import act_connmark
+from pyroute2.netlink.rtnl.tcmsg import act_vlan
 
 plugins = {'gact': act_gact,
            'bpf': act_bpf,
            'police': act_police,
            'mirred': act_mirred,
            'connmark': act_connmark,
+           'vlan': act_vlan,
            }
 
 


### PR DESCRIPTION
This adds support for the TC Vlan Action. The parameters for the python tc function are : 

- *v_action* : can be "push", "pop" or "modify"
- *id* : vlan id, integer (can be hexadecimal)
- *protocol* : can be either "802.1Q" or "802.1ad" . Those values reflect the configuration option of the tc-vlan man page
- *priority* : PCP value

The *v_action* is required, and the vlan *id* is required for "push" and "modify" actions. The protocol defaults to "802.1Q", and the priority to 0 (if unspecified).