### PR TITLE
ipdb: match RouteKey to kernel and improve route change handling on key change

### DIFF
--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -441,11 +441,11 @@ of 'prefix/mask' string and the route priority (if any)::
 
     In [1]: ipdb.routes.tables[254].idx.keys()
     Out[1]:
-    [RouteKey(dst='default', scope=0, table=254, family=2, ...),
-     RouteKey(dst='172.17.0.0/16', scope=253, table=254, ...),
-     RouteKey(dst='172.16.254.0/24', scope=253, table=254, ...),
-     RouteKey(dst='192.168.122.0/24', scope=253, table=254, ...),
-     RouteKey(dst='fe80::/64', scope=0, table=254, family=10, ...)]
+    [RouteKey(dst='default', table=254, family=2, ...),
+     RouteKey(dst='172.17.0.0/16', table=254, ...),
+     RouteKey(dst='172.16.254.0/24', table=254, ...),
+     RouteKey(dst='192.168.122.0/24', table=254, ...),
+     RouteKey(dst='fe80::/64', table=254, family=10, ...)]
 
 But a routing table in IPDB allows several variants of the
 route spec. The simplest case is to retrieve a route by

--- a/pyroute2/ipdb/routes.py
+++ b/pyroute2/ipdb/routes.py
@@ -134,6 +134,13 @@ class WatchdogKey(dict):
 
 
 # Universal route key
+# Holds the fields that the kernel uses to uniquely identify routes.
+# IPv4 allows redundant routes with different 'tos' but IPv6 does not,
+# so 'tos' is used for IPv4 but not IPv6.
+# For reference, see fib_table_insert() in
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv4/fib_trie.c#n1147
+# and fib6_add_rt2node() in
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv6/ip6_fib.c#n765
 RouteKey = namedtuple('RouteKey',
                       ('dst',
                        'table',
@@ -619,7 +626,7 @@ class Route(BaseRoute):
                     else:
                         v = 'default'
                 elif field == 'tos' and msg.get('family') != AF_INET:
-                    # ignore tos field for non-IPv4 routes,
+                    # ignore tos field for non-IPv6 routes,
                     # as it used as a key only there
                     v = None
                 elif v is None:
@@ -638,7 +645,7 @@ class Route(BaseRoute):
                     else:
                         v = ip
                 elif field == 'tos' and msg.get('family') != AF_INET:
-                    # ignore tos field for non-IPv4 routes,
+                    # ignore tos field for non-IPv6 routes,
                     # as it used as a key only there
                     v = None
                 values.append(v)
@@ -1110,7 +1117,7 @@ class RoutingTableSet(object):
 
     def gc_mark_addr(self, msg):
         ##
-        # Find invalid route records after addr delete
+        # Find invalid IPv4 route records after addr delete
         #
         # Example::
         #   $ sudo ip link add test0 type dummy
@@ -1122,9 +1129,13 @@ class RoutingTableSet(object):
         #
         # The route {'dst': '10.1.2.0/24', 'gateway': '172.18.0.1'}
         # will stay in the routing table being removed from the system.
-        # That's because the kernel doesn't send route updates in that
-        # case, so we have to calculate the update here -- or load all
-        # the routes from scratch. The latter may be far too expensive.
+        # That's because the kernel doesn't send IPv4 route updates in
+        # that case, so we have to calculate the update here -- or load
+        # all the routes from scratch. The latter may be far too
+        # expensive.
+        #
+        # See http://www.spinics.net/lists/netdev/msg254186.html for
+        # background on this kernel behavior.
 
         # Simply ignore secondary addresses, as they don't matter
         if msg['flags'] & IFA_F_SECONDARY:
@@ -1157,7 +1168,8 @@ class RoutingTableSet(object):
                             record['route']._gctime = time.time()
 
         elif family == AF_INET6:
-            # TODO: add IPv6 support
+            # Unlike IPv4, IPv6 route updates are sent after addr
+            # delete, so no need to delete them here.
             pass
         else:
             # ignore not (IPv4 or IPv6)


### PR DESCRIPTION
This solves three problems:
1. If the 'tos' field on an existing IPv4 route is changed using pyroute2, then pyroute2 currently adds a new route and fails to remove the old route.  This is fixed by adding the 'tos' to the RouteKey when appropriate (for IPv4 but not IPv6).
2. If the 'scope' or 'oif' field on an existing route is changed, then pyroute2 unnecessarily removes and re-adds the route, causing a brief outage.  This is fixed by removing these fields from the RouteKey so that the route will be updated in-place.
3. If the 'priority' field on an existing route is changed, then pyroute2 removes the old route before adding the new route, causing a brief outage.  This is fixed by adjusting the order of operations so that the new route is added before the old route is removed.