### PR TITLE
Add support for adding ports to existing ipset

### DIFF
--- a/pyroute2/ipset.py
+++ b/pyroute2/ipset.py
@@ -186,6 +186,13 @@ class IPSet(NetlinkSocket):
                             terminate=_nlmsg_error)
 
     def _entry_to_data_attrs(self, entry, etype, family):
+        """
+        Construct the required attributes for IPSET_ATTR_DATA
+            :param entry: str: Entry needed to be added to the ipset
+            :param etype: str: IPSet type, ip, net, port supported
+            :param family: socket.AF_INET*: address family of
+                           entry
+        """
         attrs = []
         if family is not None:
             if family == socket.AF_INET:

--- a/pyroute2/ipset.py
+++ b/pyroute2/ipset.py
@@ -13,6 +13,7 @@ rename, swap, test...)
 '''
 import errno
 import socket
+from re import search
 from pyroute2.netlink import NLMSG_ERROR
 from pyroute2.netlink import NLM_F_REQUEST
 from pyroute2.netlink import NLM_F_DUMP
@@ -195,6 +196,20 @@ class IPSet(NetlinkSocket):
                 ip_version = None
             else:
                 raise TypeError('unknown family')
+
+        if etype == 'port':
+            if not search(r'(^\d+-\d+$)|(^\d+$)', entry):
+                raise ValueError('Bad port or port range')
+            if '-' in entry:
+                t, f = [int(x) for x in sorted(entry.split('-'))]
+                attrs += [
+                    ['IPSET_ATTR_PORT_FROM', f],
+                    ['IPSET_ATTR_PORT_TO', t]
+                ]
+            else:
+                attrs += [['IPSET_ATTR_PORT_FROM', int(entry)]]
+            return attrs
+
         for e, t in zip(entry.split(','), etype.split(',')):
             if t in ('ip', 'net'):
                 if t == 'net':


### PR DESCRIPTION
[root@localhost pyroute2]# git log -2 --pretty=oneline
b2b7c835e07e1ab818ac0bae3fa9d9c55e02ff09 Added docstring for _entry_to_data_attrs method
561af2db37bbff4c71942517c536af18a555457c Added support for adding type:port to existing ipset
[root@localhost pyroute2]# cat TEST.py
from ipset import IPSet
a = IPSet()
import pprint
a.create(name='testport', bitmap_ports_range='1-10000', stype='bitmap:port')
a.add(name='testport', entry='8080',etype='port')
a.add(name='testport', entry='9000-9005',etype='port')
[root@localhost pyroute2]# python TEST.py
[root@localhost pyroute2]# echo $?
0
[root@localhost pyroute2]# ipset list testport
Name: testport
Type: bitmap:port
Revision: 1
Header: range 1-10000
Size in memory: 80144
References: 0
Members:
8080
9000
9001
9002
9003
9004
9005`
