### PR TITLE
Add new wiset module

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Usage
     usage
     iproute
     ipdb
+    wiset
     netns
 
 Howtos

--- a/docs/wiset.rst
+++ b/docs/wiset.rst
@@ -1,0 +1,7 @@
+.. wiset:
+
+WiSet module
+============
+
+.. automodule:: pyroute2.wiset
+    :members:

--- a/pyroute2/wiset.py
+++ b/pyroute2/wiset.py
@@ -1,0 +1,480 @@
+'''
+WiSet module
+============
+
+High level ipset support.
+
+When :doc:`ipset` is providing a direct netlink socket with low level
+functions, a :class:`WiSet` object is built to map ipset objects from kernel. It
+helps to add/remove entries, list content, etc.
+
+For example, adding an entry with :class:`pyroute2.ipset.IPSet` object
+implies to set a various number of parameters:
+
+>>> ipset = IPSet()
+>>> ipset.add("foo", "1.2.3.4/24", etype="net")
+>>> ipset.close()
+
+When they are discovered by a :class:`WiSet`:
+
+>>> wiset = load_ipset("foo")
+>>> wiset.add("1.2.3.4/24")
+
+Listing entries is also easier using :class:`WiSet`, since it parses for you
+netlink messages:
+
+>>> wiset.content
+{'1.2.3.0/24': IPStats(packets=None, bytes=None, comment=None, timeout=None)}
+'''
+
+import errno
+import uuid
+from collections import namedtuple
+from inspect import getcallargs
+from socket import AF_INET
+
+from pyroute2 import IPSet
+from pyroute2.netlink.exceptions import IPSetError
+from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_COUNTERS
+from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_COMMENT
+
+
+# Debug variable to detect netlink socket leaks
+COUNT = {"count": 0}
+
+
+def need_ipset_socket(fun):
+    """ Decorator to create netlink socket if needed.
+
+    In many of our helpers, we need to open a netlink socket. This can
+    be expensive for someone using many times the functions: instead to have
+    only one socket and use several requests, we will open it again and again.
+
+    This helper allow our functions to be flexible: the caller can pass an
+    optional socket, or do nothing. In this last case, this decorator
+    will open a socket for the caller (and close it after call)
+
+    It also help to mix helpers. One helper can call another one: the socket
+    will be opened only once. We just have to pass the ipset variable.
+
+    Note that all functions using this helper *must* use ipset as variable
+    name for the socket.
+    """
+    def wrap(*args, **kwargs):
+        callargs = getcallargs(fun, *args, **kwargs)
+        if callargs["sock"] is None:
+            # This variable is used only to debug leak in tests
+            COUNT['count'] += 1
+            with IPSet() as sock:
+                callargs["sock"] = sock
+                # We must pop kwargs here, else the function will receive
+                # a dict of dict
+                if "kwargs" in callargs:
+                    callargs.update(callargs.pop("kwargs"))
+                return fun(**callargs)  # pylint:disable=star-args
+
+        return fun(*args, **kwargs)
+
+    return wrap
+
+
+IPStats = namedtuple("IPStats", ["packets", "bytes", "comment", "timeout"])
+
+
+# pylint: disable=too-many-instance-attributes
+class WiSet(object):
+    """ Main high level ipset manipulation class.
+
+    Every high level ipset operation should be possible with this class,
+    you probably don't need other helpers of this module, except tools
+    to load data from kernel (:func:`load_all_ipsets` and :func:`load_ipset`)
+
+    For example, you can create and an entry in a ipset just with:
+
+    >>> with WiSet(name="mysuperipset") as myset:
+    >>>    myset.create()             # add the ipset in the kernel
+    >>>    myset.add("198.51.100.1")  # add one IP to the set
+
+    Netlink sockets are opened by __enter__ and __exit__ function, so you don't
+    have to manage it manually if you use the "with" keyword.
+
+    If you want to manage it manually (for example for long operation in
+    a daemon), you can do the following:
+
+    >>> myset = WiSet(name="mysuperipset")
+    >>> myset.open_netlink()
+    >>> # do stuff
+    >>> myset.close_netlink()
+
+    You can also don't initiate at all any netlink socket, this code will work:
+
+    >>> myset = WiSet(name="mysuperipset")
+    >>> myset.create()
+    >>> myset.destroy()
+
+    But do it very carefully. In that case, a netlink socket will be opened
+    in background for any operation. No socket will be leaked, but that
+    can consume resources.
+
+    You can also instantiate WiSet objects with :func:`load_all_ipsets` and
+    :func:`load_ipset`:
+
+    >>> all_sets_dict = load_all_ipsets()
+    >>> one_set = load_ipset(name="myset")
+
+    Have a look on content variable if you need list of entries in the Set.
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name=None, attr_type='hash:ip', family=AF_INET,
+                 sock=None, timeout=None, counters=False, comment=False,
+                 revision=None):
+        self.name = name
+        self.hashsize = None
+        self._attr_type = None
+        self.entry_type = None
+        self.attr_type = attr_type
+        self.family = family
+        self._content = None
+        self.sock = sock
+        self.timeout = timeout
+        self.counters = counters
+        self.comment = comment
+        self.revision = revision
+
+    def open_netlink(self):
+        """ Open manually a netlink socket. You can use "with WiSet()" instead
+        """
+        if self.sock is None:
+            self.sock = IPSet()
+
+    def close_netlink(self):
+        """ Clone any opened netlink socket """
+        if self.sock is not None:
+            self.sock.close()
+            self.sock = None
+
+    @property
+    def attr_type(self):
+        return self._attr_type
+
+    @attr_type.setter
+    def attr_type(self, value):
+        self._attr_type = value
+        self.entry_type = value.split(":", 1)[1]
+
+    def __enter__(self):
+        self.open_netlink()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close_netlink()
+
+    @classmethod
+    def from_netlink(cls, ndmsg, content=False):
+        """ Create a ipset objects based on a parsed netlink message
+
+        :param ndmsg: the netlink message to parse
+        :param content: should we fill (and parse) entries info (can be slow
+                        on very large set)
+        :type content: bool
+        """
+        self = cls()
+        self.attr_type = ndmsg.get_attr("IPSET_ATTR_TYPENAME")
+        self.name = ndmsg.get_attr("IPSET_ATTR_SETNAME")
+        self.hashsize = ndmsg.get_attr("IPSET_ATTR_HASHSIZE")
+        self.family = ndmsg.get_attr("IPSET_ATTR_FAMILY")
+        self.revision = ndmsg.get_attr("IPSET_ATTR_REVISION")
+        data = ndmsg.get_attr("IPSET_ATTR_DATA")
+        self.timeout = data.get_attr("IPSET_ATTR_TIMEOUT")
+        flags = data.get_attr("IPSET_ATTR_CADT_FLAGS")
+        if flags is not None:
+            self.counters = bool(flags & IPSET_FLAG_WITH_COUNTERS)
+            self.comment = bool(flags & IPSET_FLAG_WITH_COMMENT)
+
+        if content:
+            self.update_dict_content(ndmsg)
+
+        return self
+
+    def update_dict_content(self, ndmsg):
+        """ Update a dictionary statistics with values sent in netlink message
+
+        :param ndmsg: the netlink message
+        :type ndmsg: netlink message
+
+        """
+        family = "IPSET_ATTR_IPADDR_IPV4"
+        ip_attr = "IPSET_ATTR_IP_FROM"
+        if self._content is None:
+            self._content = {}
+
+        timeout = None
+        entries = ndmsg.get_attr("IPSET_ATTR_ADT").get_attrs("IPSET_ATTR_DATA")
+        for entry in entries:
+            key = ""
+            for parse_type in self.entry_type.split(","):
+                if parse_type == "ip":
+                    ip = entry.get_attr(ip_attr).get_attr(family)
+                    key += ip
+                elif parse_type == "net":
+                    ip = entry.get_attr(ip_attr).get_attr(family)
+                    key += ip
+                    cidr = entry.get_attr("IPSET_ATTR_CIDR")
+                    if cidr is not None:
+                        key += "/{0}".format(cidr)
+                elif parse_type == "iface":
+                    key += entry.get_attr("IPSET_ATTR_IFACE")
+                elif parse_type == "set":
+                    key += entry.get_attr("IPSET_ATTR_NAME")
+                key += ","
+
+            key = key.strip(",")
+
+            if self.timeout is not None:
+                timeout = entry.get_attr("IPSET_ATTR_TIMEOUT")
+            value = IPStats(packets=entry.get_attr("IPSET_ATTR_PACKETS"),
+                            bytes=entry.get_attr("IPSET_ATTR_BYTES"),
+                            comment=entry.get_attr("IPSET_ATTR_COMMENT"),
+                            timeout=timeout)
+            self._content[key] = value
+
+    def create(self, **kwargs):
+        """ Insert this Set in the kernel
+
+        You can pass in kwargs all options supported by ipset module, like
+        counters, comments, hashsize, etc. See :doc:`ipset` documentation.
+        """
+        create_ipset(self.name, stype=self.attr_type, family=self.family,
+                     sock=self.sock, timeout=self.timeout,
+                     comment=self.comment, counters=self.counters, **kwargs)
+
+    def destroy(self):
+        """ Destroy this ipset in the kernel list.
+
+        It does not delete this python object (any content or other stored
+        values are keep in memory). This function will fail if the ipset is
+        still referenced (by example in iptables rules), you have been warned.
+        """
+        destroy_ipset(self.name, sock=self.sock)
+
+    def add(self, entry, **kwargs):
+        """ Add an entry in this ipset.
+
+        If counters are enabled on the set, reset by default the value when
+        we add the element. Without this reset, kernel sometimes store old
+        values and can add very strange behavior on counters.
+        """
+        if self.counters:
+            kwargs["packets"] = kwargs.pop("packets", 0)
+            kwargs["bytes"] = kwargs.pop("bytes", 0)
+        add_ipset_entry(self.name, entry, etype=self.entry_type,
+                        sock=self.sock, **kwargs)
+
+    def delete(self, entry, **kwargs):
+        """ Delete/remove an entry in this ipset """
+        delete_ipset_entry(self.name, entry, etype=self.entry_type,
+                           sock=self.sock, **kwargs)
+
+    def test(self, entry, **kwargs):
+        """ Test if an entry is in this ipset """
+        return test_ipset_entry(self.name, entry, etype=self.entry_type,
+                                sock=self.sock, **kwargs)
+
+    def test_list(self, entries, **kwargs):
+        """ Test if a list of a set of entries is in this ipset
+
+        Return a set of entries found in the IPSet
+        """
+        return test_ipset_entries(self.name, entries, etype=self.entry_type,
+                                  sock=self.sock, **kwargs)
+
+    def update_content(self):
+        """ Update the content dictionary with values from kernel """
+        self._content = {}
+        update_wiset_content(self, sock=self.sock)
+
+    def flush(self):
+        """ Flush entries of the ipset """
+        flush_ipset(self.name, sock=self.sock)
+
+    @property
+    def content(self):
+        """ Dictionary of entries in the set.
+
+        Keys are IP addresses (as string), values are IPStats tuples.
+        """
+        if self._content is None:
+            self.update_content()
+
+        return self._content
+
+    def insert_list(self, entries):
+        """ Just a small helper to reduce the number of loops in main code. """
+        for entry in entries:
+            self.add(entry)
+
+    def replace_entries(self, new_list):
+        """ Replace the content of an ipset with a new list of entries.
+
+        This operation is like a flush() and adding all entries one by one. But
+        this call is atomic: it creates a temporary ipset and swap the content.
+
+        :param new_list: list of entries to add
+        :type new_list: list or :py:class:`set`
+        """
+        temp_name = str(uuid.uuid4())[0:8]
+        # Get a copy of ourself
+        temp = load_ipset(self.name, sock=self.sock)
+        temp.name = temp_name
+        temp.sock = self.sock
+        temp.create()
+        temp.insert_list(new_list)
+        swap_ipsets(self.name, temp_name, sock=self.sock)
+        temp.destroy()
+
+
+@need_ipset_socket
+def create_ipset(name, stype=None, family=AF_INET, exclusive=False,
+                 sock=None, **kwargs):
+    """ Create an ipset. """
+    sock.create(name, stype=stype, family=family, exclusive=exclusive,
+                **kwargs)
+
+
+@need_ipset_socket
+def load_all_ipsets(content=False, sock=None, inherit_sock=False, prefix=None):
+    """ List all ipset as WiSet objects.
+
+    Get full ipset data from kernel and parse it in WiSet objects. Result is
+    a dictionary with ipset names as keys, and WiSet objects as values.
+
+    :param content: parse the list of entries and fill it in WiSet content
+                    dictionary
+    :type content: bool
+    :param inherit_sock: use the netlink sock passed in ipset arg to
+                         fill WiSets sock
+    :type inherit_sock: bool
+    :param prefix: filter out all ipset with a name not beginning by this prefix
+    :type prefix: str or None
+    """
+    res = {}
+    for myset in sock.list():
+        # on large sets, we can receive data in several messages
+        name = myset.get_attr("IPSET_ATTR_SETNAME")
+        if prefix is not None and not name.startswith(prefix):
+            continue
+        if name not in res:
+            wiset = WiSet.from_netlink(myset, content=content)
+            if inherit_sock:
+                wiset.sock = sock
+            res[wiset.name] = wiset
+        elif content:
+            res[wiset.name].update_dict_content(myset)
+    return res
+
+
+@need_ipset_socket
+def load_ipset(name, content=False, sock=None, inherit_sock=False):
+    """ Get one ipset as WiSet object
+
+    Helper to get current WiSet object. More efficient that
+    :func:`load_all_ipsets` since the kernel does the filtering itself.
+
+    Return None if the ipset does not exist
+
+    :param name: name of the ipset
+    :type name: str
+    :param content: parse or not content and statistics on entries
+    :type content: bool
+    :param inherit_sock: use the netlink sock passed in ipset arg to
+                         fill WiSet sock
+    :type inherit_sock: bool
+    """
+    res = None
+    for msg in sock.list(name=name):
+        if res is None:
+            res = WiSet.from_netlink(msg, content=content)
+            if inherit_sock:
+                res.sock = sock
+        elif content:
+            res.update_dict_content(msg)
+    return res
+
+
+@need_ipset_socket
+def update_wiset_content(wiset, sock=None):
+    """ Update content/statistics of a wiset.
+
+    You should never call yourself this function. It is only a helper to use the
+    :func:`need_ipset_socket` decorator out of WiSet object.
+    """
+    for msg in sock.list(name=wiset.name):
+        wiset.update_dict_content(msg)
+
+
+@need_ipset_socket
+def destroy_ipset(name, sock=None):
+    """ Remove an ipset in the kernel. """
+    sock.destroy(name)
+
+
+@need_ipset_socket
+def add_ipset_entry(name, entry, sock=None, **kwargs):
+    """ Add an entry """
+    sock.add(name, entry, **kwargs)
+
+
+@need_ipset_socket
+def delete_ipset_entry(name, entry, sock=None, **kwargs):
+    """ Remove one entry """
+    sock.delete(name, entry, **kwargs)
+
+
+@need_ipset_socket
+def test_ipset_exist(name, sock=None):
+    """ Test if the given ipset exist """
+    try:
+        sock.headers(name)
+        return True
+    except IPSetError as e:
+        if e.code == errno.ENOENT:
+            return False
+        raise
+
+
+@need_ipset_socket
+def test_ipset_entry(name, entry, sock=None, **kwargs):
+    """ Test if an entry is in one ipset """
+    return sock.test(name, entry, **kwargs)
+
+
+@need_ipset_socket
+def test_ipset_entries(name, entries, sock=None, **kwargs):
+    """ Test a list (or a set) of entries.
+    """
+    res = set()
+    for entry in entries:
+        if sock.test(name, entry, **kwargs):
+            res.add(entry)
+    return res
+
+
+@need_ipset_socket
+def flush_ipset(name, sock=None):
+    """ Flush all ipset content """
+    sock.flush(name)
+
+
+@need_ipset_socket
+def swap_ipsets(name_a, name_b, sock=None):
+    """ Swap the content of ipset a and b.
+
+    ipsets must have compatible content.
+    """
+    sock.swap(name_a, name_b)
+
+
+def get_ipset_socket(**kwargs):
+    """ Get a socket that one can pass to several WiSet objects """
+    return IPSet(**kwargs)

--- a/tests/general/test_wiset.py
+++ b/tests/general/test_wiset.py
@@ -1,0 +1,292 @@
+from time import sleep
+
+from pyroute2.common import uifname
+from pyroute2.netlink.exceptions import IPSetError
+from pyroute2.wiset import WiSet, load_all_ipsets, COUNT, get_ipset_socket
+from pyroute2.wiset import test_ipset_exist, load_ipset
+from utils import require_user
+
+
+class WiSet_test(object):
+
+    def setUp(self):
+        self.name = uifname()
+
+    def test_create_one_ipset(self, sock=None):
+        require_user('root')
+        with WiSet(name=self.name, sock=sock) as myset:
+            myset.create()
+
+            list_wiset = load_all_ipsets(sock=sock)
+            assert test_ipset_exist(self.name, sock=sock)
+            myset.destroy()
+
+            assert not test_ipset_exist(self.name, sock=sock)
+            assert self.name in list_wiset
+            assert self.name not in load_all_ipsets(sock=sock)
+
+    def test_create_ipset_twice(self, sock=None):
+        require_user('root')
+        with WiSet(name=self.name, sock=sock) as myset:
+            myset.create()
+
+            try:
+                myset.create(exclusive=True)
+                assert False
+            except IPSetError:
+                pass
+
+            myset.create(exclusive=False)
+            myset.destroy()
+            assert self.name not in load_all_ipsets(sock=sock)
+
+    def test_check_ipset_stats(self, sock=None):
+        require_user('root')
+
+        def test_stats(myset, res=None, counters=False):
+            myset.counters = counters
+            myset.create()
+            myset.add("8.8.8.8", packets=res, bytes=res)
+            myset.update_content()
+            stats = myset.content
+            myset.flush()
+
+            assert stats["8.8.8.8"].packets == res
+            assert stats["8.8.8.8"].bytes == res
+
+            myset.add("8.8.8.8")
+            myset.update_content()
+            stats = myset.content
+            if res is not None:
+                res = 0
+            assert stats["8.8.8.8"].packets == res
+            assert stats["8.8.8.8"].bytes == res
+            myset.destroy()
+
+        with WiSet(name=self.name, sock=sock) as myset:
+            test_stats(myset, res=10, counters=True)
+            test_stats(myset)
+
+    def test_ipset_with_comment(self, sock=None):
+        require_user('root')
+        comment = "test comment"
+
+        with WiSet(name=self.name, sock=sock, comment=True) as myset:
+            myset.create()
+            myset.add("8.8.8.8", comment=comment)
+            set_list = myset.content
+            myset.destroy()
+
+        assert set_list["8.8.8.8"].comment == comment
+
+    def test_list_on_large_set(self, sock=None):
+        require_user('root')
+        set_size = 30000
+        base_ip = "10.10.%d.%d"
+
+        with WiSet(name=self.name, sock=sock) as myset:
+            myset.create()
+            for i in range(0, set_size):
+                myset.add(base_ip % (i / 255, i % 255))
+            stats_len = len(myset.content)
+            stats_len2 = len(load_ipset(self.name, content=True,
+                                        sock=sock).content)
+            myset.destroy()
+
+        assert stats_len == set_size
+        assert stats_len2 == set_size
+
+    def test_remove_entry(self, sock=None):
+        require_user('root')
+        ip = "1.1.1.1"
+
+        with WiSet(name=self.name, sock=sock, counters=True) as myset:
+            myset.create()
+            myset.add(ip)
+            assert ip in myset.content
+            myset.delete(ip)
+            myset.update_content()
+            assert ip not in myset.content
+            myset.destroy()
+
+    def test_flush(self, sock=None):
+        require_user('root')
+        ip_list = ["1.2.3.4", "1.1.1.1", "7.7.7.7"]
+
+        with WiSet(name=self.name, sock=sock) as myset:
+            myset.create()
+            for ip in ip_list:
+                myset.add(ip)
+                assert myset.test(ip)
+            myset.flush()
+            for ip in ip_list:
+                assert not myset.test(ip)
+            myset.destroy()
+
+    def test_list_in(self, sock=None):
+        require_user('root')
+        ip_list_good = ["1.2.3.4", "1.1.1.1", "7.7.7.7"]
+        ip_list_bad = ["4.4.4.4", "5.5.5.5", "6.6.6.6"]
+
+        with WiSet(name=self.name, sock=sock) as myset:
+            myset.create()
+            myset.replace_entries(ip_list_good)
+            res_test = myset.test_list(ip_list_good + ip_list_bad)
+            for ip in ip_list_good:
+                assert ip in res_test
+            for ip in ip_list_bad:
+                assert ip not in res_test
+
+            myset.destroy()
+
+    def test_timeout(self, sock=None):
+        require_user('root')
+        ip = "1.2.3.4"
+        timeout = 2
+
+        with WiSet(name=self.name, sock=sock, timeout=timeout) as myset:
+            myset.create()
+            myset.add(ip)
+            sleep(3)
+            myset.update_content()
+            assert ip not in myset.content
+            assert timeout == load_ipset(self.name).timeout
+            myset.add(ip, timeout=0)
+            myset.update_content()
+            assert 0 == myset.content[ip].timeout
+            myset.destroy()
+
+    def test_basic_attribute_reads(self, sock=None):
+        require_user('root')
+        for value in [True, False]:
+            myset = WiSet(name=self.name, sock=sock, counters=value,
+                          comment=value)
+            if sock is None:
+                myset.open_netlink()
+            myset.create()
+            from_netlink = load_ipset(self.name, sock=sock)
+            assert value == from_netlink.comment
+            assert value == from_netlink.counters
+            myset.destroy()
+            if sock is None:
+                myset.close_netlink()
+
+    def test_replace_content(self, sock=None):
+        require_user('root')
+        list_a = ["1.2.3.4", "2.3.4.5", "6.7.8.9"]
+        list_b = ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+
+        def test_replace(content_a, content_b):
+            myset = WiSet(name=self.name, sock=sock)
+            myset.create()
+            myset.insert_list(content_a)
+            myset.update_content()
+            for value in content_a:
+                assert value in myset.content
+            myset.replace_entries(content_b)
+            myset.update_content()
+            for (old, new) in zip(content_a, content_b):
+                assert old not in myset.content
+                assert new in myset.content
+            myset.destroy()
+
+        test_replace(list_a, list_b)
+        test_replace(set(list_a), set(list_b))
+
+    def test_hash_net_ipset(self, sock=None):
+        require_user('root')
+        to_add = ["192.168.1.0/24", "192.168.2.0/23", "10.0.0.0/8"]
+        atype = "hash:net"
+
+        with WiSet(name=self.name, attr_type=atype, sock=sock) as myset:
+            myset.create()
+            myset.insert_list(to_add)
+            for value in to_add:
+                assert value in myset.content
+            myset.destroy()
+
+    def test_two_dimensions_ipset(self, sock=None):
+        require_user('root')
+        to_add = ["192.168.1.0/24,eth0", "192.168.2.0/23,eth1",
+                  "10.0.0.0/8,tun0"]
+        atype = "hash:net,iface"
+
+        with WiSet(name=self.name, attr_type=atype, sock=sock) as myset:
+            myset.create()
+            myset.insert_list(to_add)
+            for value in to_add:
+                assert value in myset.content
+            myset.destroy()
+
+    def test_stats_consistency(self, sock=None):
+        """ Test several way to fill the statistics of one IPSet """
+        require_user('root')
+        entries = ["1.2.3.4", "1.2.3.5", "1.2.3.6"]
+
+        myset = WiSet(name=self.name, sock=sock)
+        myset.create()
+        myset.insert_list(entries)
+
+        myset_lists = load_all_ipsets(sock=sock, content=True)[self.name]
+        for value in entries:
+            assert value in myset_lists.content
+
+        myset_list = load_ipset(self.name, sock=sock, content=True)
+        for value in entries:
+            assert value in myset_list.content
+
+        myset.destroy()
+
+    def test_hashnet_with_comment(self, sock=None):
+        require_user('root')
+        comment = "abcdef"
+        myset = WiSet(name=self.name, attr_type="hash:net", comment=True,
+                      sock=sock)
+        myset.create()
+
+        inherit_sock = sock is not None
+        myset = load_ipset(self.name, sock=sock,
+                           inherit_sock=inherit_sock)
+        assert myset.comment
+
+        myset.add("192.168.1.1", comment=comment)
+        myset.update_content()
+
+        assert myset.content["192.168.1.1/32"].comment == comment
+
+        myset.destroy()
+
+    def test_revision(self, sock=None):
+        require_user('root')
+        myset = WiSet(name=self.name, attr_type="hash:net", sock=sock)
+
+        myset.create()
+        assert load_ipset(self.name, sock=sock).revision >= 6
+
+        myset.destroy()
+
+    def test_force_attr_revision(self):
+        require_user('root')
+        sock = get_ipset_socket(attr_revision=2)
+
+        myset = WiSet(name=self.name, attr_type="hash:net", sock=sock)
+        myset.create()
+        assert load_ipset(self.name, sock=sock).revision >= 2
+
+        myset.destroy()
+        sock.close()
+
+    def test_ipset_context(self):
+        before_count = COUNT["count"]
+        func = [self.test_create_one_ipset, self.test_create_ipset_twice,
+                self.test_check_ipset_stats, self.test_list_on_large_set,
+                self.test_remove_entry, self.test_flush,
+                self.test_basic_attribute_reads, self.test_replace_content,
+                self.test_hash_net_ipset, self.test_stats_consistency,
+                self.test_list_in, self.test_hashnet_with_comment,
+                self.test_revision]
+        for fun in func:
+            sock = get_ipset_socket()
+            fun(sock=sock)
+            assert before_count == COUNT['count']
+            sock.close()


### PR DESCRIPTION
IPSet object from ipset.py is providing a low level API to manage
NFNetlink sockets. It's "stateless" since it does not have any context
of the ipset manipulated (for example, to know ipset entries and help to
parse responses). Moreover, it's made to manipulate all ipsets in the
same time.

This module provides or more high level API, based on WiSet object. A
WiSet is directly mapped to a real ipset object in kernel, and help to
store metadata like:
 - type of entries
 - configuration of ipset (counters enabled, comments, etc)
 - low level configuration like hash table size, module revision, etc

All data are stored in native python format, and you don't need to know
IPSET_ATTR_* variable to set or read values. Netlink interface is fully
abstract with this object.

It's help to run a batch of command on a set without to have to provide
at each call all relevant metadata. It also provides helpers like
"replace_entries" method, to fill a set with a new content is an atomic
call.

Since some magic is made to abstract netlink socket provided by IPSet
object, we provide several way to make life of users easier:

 - you never need to explicit open/close of sockets if you don't want to
   (easy to use)
 - you may provide a already opened socket at each call (performance)
 - WiSet provides __enter__ and __close__ methods, so it's easy to use
   in a pythonic way

However, some features are not yet implemented:
 - we only support IPv4 addresses
 - we don't support all ipset modules provided by recent kernels
 - only basic flags are currently supported

This code is running in production since a year on many devices. I'm
sorry to not provide a real git history of changes, but the project
began out of pyroute2 repository. The backport of code from our
externals libraries and pyroute2 project was not so easy.

Signed-off-by: Florent Fourcot <florent.fourcot@wifirst.fr>
Signed-off-by: Florian Vichot <florian.vichot@wifirst.fr>
Signed-off-by: Étienne Noss <etienne.noss@wifirst.fr>
Signed-off-by: Romain Bellan <romain.bellan@wifirst.fr>