### PR TITLE
fix NLAs for vti6 device

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/plugins/vti6.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/plugins/vti6.py
@@ -6,6 +6,6 @@ class vti6(nla):
                ('IFLA_VTI_LINK', 'uint32'),
                ('IFLA_VTI_IKEY', 'be32'),
                ('IFLA_VTI_OKEY', 'be32'),
-               ('IFLA_VTI_FWMARK', 'uint32'),
                ('IFLA_VTI_LOCAL', 'ip6addr'),
-               ('IFLA_VTI_REMOTE', 'ip6addr'))
+               ('IFLA_VTI_REMOTE', 'ip6addr'),
+               ('IFLA_VTI_FWMARK', 'uint32'))


### PR DESCRIPTION
initial vti6 commit used wrong field order