### PR TITLE
Fix for IPRoute objects that can still be used after close in Python 2

### DIFF
--- a/pyroute2/netlink/nlsocket.py
+++ b/pyroute2/netlink/nlsocket.py
@@ -872,17 +872,6 @@ class NetlinkSocket(NetlinkMixin):
                                            SOCK_DGRAM,
                                            self.family,
                                            self._fileno)
-            for name in ('getsockname', 'getsockopt', 'makefile',
-                         'setsockopt', 'setblocking', 'settimeout',
-                         'gettimeout', 'shutdown', 'recvfrom',
-                         'recvfrom_into', 'fileno'):
-                setattr(self, name, getattr(self._sock, name))
-
-            self._sendto = getattr(self._sock, 'sendto')
-            self._recv = getattr(self._sock, 'recv')
-            self._recv_into = getattr(self._sock, 'recv_into')
-            # setup fast-track
-            self.recv_ft = getattr(self._sock, 'recv')
             self.sendto_gate = self._gate
 
             # monkey patch recv_into on Python 2.6
@@ -897,6 +886,19 @@ class NetlinkSocket(NetlinkMixin):
             self.setsockopt(SOL_SOCKET, SO_RCVBUF, 1024 * 1024)
             if self.all_ns:
                 self.setsockopt(SOL_NETLINK, NETLINK_LISTEN_ALL_NSID, 1)
+
+    def __getattr__(self, attr):
+        if attr in ('getsockname', 'getsockopt', 'makefile',
+                    'setsockopt', 'setblocking', 'settimeout',
+                    'gettimeout', 'shutdown', 'recvfrom',
+                     'recvfrom_into', 'fileno'):
+            return getattr(self._sock, attr)
+        elif attr in ('_sendto', '_recv', '_recv_into'):
+            return getattr(self._sock, attr.lstrip("_"))
+        elif attr == "recv_ft":
+            return self._sock.recv
+
+        raise AttributeError(attr)
 
     def _gate(self, msg, addr):
         msg.reset()

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -25,6 +25,7 @@ from utils import create_link
 from utils import remove_link
 from utils import skip_if_not_supported
 from nose.plugins.skip import SkipTest
+from nose.tools import assert_raises
 
 
 class TestSetup(object):
@@ -45,6 +46,15 @@ class TestSetup(object):
             IPRoute(fileno=13)
         except NotImplementedError:
             pass
+
+    def test_close(self):
+        ip = IPRoute()
+        ip.get_links()
+        ip.close()
+
+        # Shouldn't be able to use the socket after closing
+        with assert_raises(socket.error):
+            ip.get_links()
 
     def test_fileno(self):
         require_python(3)


### PR DESCRIPTION
Hello,

I noticed IPRoute contexts could still be used after being closed in Python 2. I assume I'm not the first one to stumble upon this, but it has caused inconsistent behavior between Python versions in our codebase so I figured it warranted a fix.

The gist of the issue is that `NetlinkSocket` stores references to the underlying socket methods, which can change (and do). So instead of storing references I used `__getattr__` to always return the "current" methods.

The reference-based approach caused IPRoute sockets to be in an inconsistent state when closed:
- the socket methods are replaced by dummies at closing time
- the stored reference still points to the old method
- the underlying os-level socket is not necessarily closed
Thus data still could be sent over the socket even if it was considered closed.

Only Python 2 is affected, because in Python 3 socket methods point to the "real thing" and are not replaced by dummies when closing.

I guess a `__getattr__` call could have a performance overhead compared to the old method, so tell me if this is a problem and I'll think of another way.

Cheers,
Étienne