### PR TITLE
added 32 bit aarch64 variant, found on chromebook plus

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -99,7 +99,8 @@ __NR = {'x86_': {'64bit': 308},
         'mips': {'32bit': 4344,
                  '64bit': 5303},  # FIXME: NABI32?
         'armv': {'32bit': 375},
-        'aarc': {'64bit': 268},  # FIXME: EABI vs. OABI?
+        'aarc': {'32bit': 375,
+                 '64bit': 268},  # FIXME: EABI vs. OABI?
         'ppc6': {'64bit': 350}}
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 


### PR DESCRIPTION
Confirmed as working after switching code to 375 (though if that hadn't worked, I'd have been lost).

```
>>> platform.uname()
uname_result(system='Linux', node='localhost', release='4.4.86-11979-g09b49365a3c4', version='#1 SMP PREEMPT Mon Jan 8 23:12:27 PST 2018', machine='aarch64', processor='ARMv8 Processor rev 4 (v8l)')
>>> platform.machine()
'aarch64'
>>> platform.architecture()
('32bit', '')
```

ChromeOS Version 63.0.3239.140 (Official Build) (32-bit), released January 2018.