### PR TITLE
ipset: add skbinfo capability

### DIFF
--- a/pyroute2/netlink/nfnetlink/ipset.py
+++ b/pyroute2/netlink/nfnetlink/ipset.py
@@ -1,3 +1,4 @@
+import struct
 from pyroute2.netlink import nla
 from pyroute2.netlink import NLA_F_NESTED
 from pyroute2.netlink import NLA_F_NET_BYTEORDER
@@ -118,9 +119,37 @@ class ipset_msg(nfgen_msg):
                        (24, 'IPSET_ATTR_BYTES', 'be64', NLA_F_NET_BYTEORDER),
                        (25, 'IPSET_ATTR_PACKETS', 'be64', NLA_F_NET_BYTEORDER),
                        (26, 'IPSET_ATTR_COMMENT', 'asciiz'),
-                       (27, 'IPSET_ATTR_SKBMARK', 'hex'),
-                       (28, 'IPSET_ATTR_SKBPRIO', 'be32'),
-                       (29, 'IPSET_ATTR_SKBQUEUE', 'hex'))
+                       (27, 'IPSET_ATTR_SKBMARK', 'skbmark'),
+                       (28, 'IPSET_ATTR_SKBPRIO', 'skbprio'),
+                       (29, 'IPSET_ATTR_SKBQUEUE', 'be16',
+                        NLA_F_NET_BYTEORDER))
+
+            class skbinfo_base(nla):
+                nla_flags = NLA_F_NET_BYTEORDER
+
+                def calcmask(self):
+                    bits = struct.calcsize(self.fields[0][1]) * 4
+                    return (1 << bits) - 1, bits
+
+                def encode(self):
+                    if isinstance(self['value'], tuple):
+                        mask, bits = self.calcmask()
+                        self['value'] = (self['value'][0] << bits) | \
+                                        (self['value'][1] & mask)
+                    nla.encode(self)
+
+                def decode(self):
+                    nla.decode(self)
+                    if not isinstance(self['value'], tuple):
+                        mask, bits = self.calcmask()
+                        self['value'] = (self['value'] >> bits,
+                                         self['value'] & mask)
+
+            class skbmark(skbinfo_base):
+                fields = [('value', '>Q')]
+
+            class skbprio(skbinfo_base):
+                fields = [('value', '>I')]
 
     class cadt_data(ipset_base):
         nla_flags = NLA_F_NESTED

--- a/pyroute2/netlink/nfnetlink/ipset.py
+++ b/pyroute2/netlink/nfnetlink/ipset.py
@@ -1,4 +1,3 @@
-import struct
 from pyroute2.netlink import nla
 from pyroute2.netlink import NLA_F_NESTED
 from pyroute2.netlink import NLA_F_NET_BYTEORDER
@@ -124,32 +123,13 @@ class ipset_msg(nfgen_msg):
                        (29, 'IPSET_ATTR_SKBQUEUE', 'be16',
                         NLA_F_NET_BYTEORDER))
 
-            class skbinfo_base(nla):
+            class skbmark(nla):
                 nla_flags = NLA_F_NET_BYTEORDER
+                fields = [('value', '>II')]
 
-                def calcmask(self):
-                    bits = struct.calcsize(self.fields[0][1]) * 4
-                    return (1 << bits) - 1, bits
-
-                def encode(self):
-                    if isinstance(self['value'], tuple):
-                        mask, bits = self.calcmask()
-                        self['value'] = (self['value'][0] << bits) | \
-                                        (self['value'][1] & mask)
-                    nla.encode(self)
-
-                def decode(self):
-                    nla.decode(self)
-                    if not isinstance(self['value'], tuple):
-                        mask, bits = self.calcmask()
-                        self['value'] = (self['value'] >> bits,
-                                         self['value'] & mask)
-
-            class skbmark(skbinfo_base):
-                fields = [('value', '>Q')]
-
-            class skbprio(skbinfo_base):
-                fields = [('value', '>I')]
+            class skbprio(nla):
+                nla_flags = NLA_F_NET_BYTEORDER
+                fields = [('value', '>HH')]
 
     class cadt_data(ipset_base):
         nla_flags = NLA_F_NESTED

--- a/tests/general/test_ipset.py
+++ b/tests/general/test_ipset.py
@@ -63,7 +63,10 @@ class TestIPSet(object):
                     res[entry] = (x.get_attr("IPSET_ATTR_PACKETS"),
                                   x.get_attr("IPSET_ATTR_BYTES"),
                                   x.get_attr("IPSET_ATTR_COMMENT"),
-                                  x.get_attr("IPSET_ATTR_TIMEOUT"))
+                                  x.get_attr("IPSET_ATTR_TIMEOUT"),
+                                  x.get_attr("IPSET_ATTR_SKBMARK"),
+                                  x.get_attr("IPSET_ATTR_SKBPRIO"),
+                                  x.get_attr("IPSET_ATTR_SKBQUEUE"))
             return res
         except:
             return {}
@@ -204,6 +207,39 @@ class TestIPSet(object):
         self.ip.add(name, ipaddr, comment=comment)
         assert ipaddr in self.list_ipset(name)
         assert self.list_ipset(name)[ipaddr][2] == comment
+        self.ip.destroy(name)
+
+    def test_skbmark(self):
+        require_user('root')
+        name = str(uuid4())[:16]
+        ipaddr = '172.16.202.202'
+        skbmark = (0x100, 0xffffffff)
+        self.ip.create(name, skbinfo=True)
+        self.ip.add(name, ipaddr, skbmark=skbmark)
+        assert ipaddr in self.list_ipset(name)
+        assert self.list_ipset(name)[ipaddr][4] == skbmark
+        self.ip.destroy(name)
+
+    def test_skbprio(self):
+        require_user('root')
+        name = str(uuid4())[:16]
+        ipaddr = '172.16.202.202'
+        skbprio = (1, 10)
+        self.ip.create(name, skbinfo=True)
+        self.ip.add(name, ipaddr, skbprio=skbprio)
+        assert ipaddr in self.list_ipset(name)
+        assert self.list_ipset(name)[ipaddr][5] == skbprio
+        self.ip.destroy(name)
+
+    def test_skbqueue(self):
+        require_user('root')
+        name = str(uuid4())[:16]
+        ipaddr = '172.16.202.202'
+        skbqueue = 1
+        self.ip.create(name, skbinfo=True)
+        self.ip.add(name, ipaddr, skbqueue=skbqueue)
+        assert ipaddr in self.list_ipset(name)
+        assert self.list_ipset(name)[ipaddr][6] == skbqueue
         self.ip.destroy(name)
 
     def test_maxelem(self):


### PR DESCRIPTION
Hi,

This PR adds support for the `skbinfo` capability into the `ipset` which includes setting `skbmark`, `skbprio`, and `skbqueue` at adding entry.

Thanks.