### PR TITLE
dummy: Clarifyciation for TCP ss prep

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -44,7 +44,7 @@ structure is as follows::
     NLA header:
         uint16 length
         uint16 type
-    NLA data:
+    NLA data:1297,
         data-specific struct
         # optional:
         NLA
@@ -1259,11 +1259,11 @@ class nlmsg_base(dict):
         nla_map = []
         for item in self.nla_map:
             if not isinstance(item[-1], int):
-                item = list(item)
-                item.append(0)
+                item = item + (0,)
             nla_map.append(item)
 
         # detect, whether we have pre-defined keys
+        print nla_map[0][0]
         if not isinstance(nla_map[0][0], int):
             # create enumeration
             nla_types = enumerate((i[0] for i in nla_map))

--- a/pyroute2/netlink/diag/__init__.py
+++ b/pyroute2/netlink/diag/__init__.py
@@ -1,5 +1,6 @@
 from socket import AF_UNIX
 from pyroute2.netlink import nlmsg
+from pyroute2.netlink import nla 
 from pyroute2.netlink import NLM_F_REQUEST
 from pyroute2.netlink import NLM_F_ROOT
 from pyroute2.netlink import NLM_F_MATCH
@@ -66,6 +67,9 @@ class unix_diag_msg(nlmsg):
               ('udiag_ino', 'I'),
               ('udiag_cookie', 'Q'))
 
+    nla_map = ((UDIAG_SHOW_PEER, 'UDIAG_SHOW_PEER', 'uint32'), 
+               ( UDIAG_SHOW_NAME, 'UDIAG_SHOW_NAME', 'string' ))
+
 
 class MarshalDiag(Marshal):
     type_format = 'B'
@@ -77,6 +81,10 @@ class MarshalDiag(Marshal):
     # to choose the proper class
     msg_map = {AF_UNIX: unix_diag_msg}
 
+def udiag_tst_cb(msg):
+    #print '---'
+    #print msg
+    pass
 
 class DiagSocket(NetlinkSocket):
     '''
@@ -113,4 +121,4 @@ class DiagSocket(NetlinkSocket):
         req['udiag_show'] = show
 
         return self.nlm_request(req, SOCK_DIAG_BY_FAMILY,
-                                NLM_F_REQUEST | NLM_F_ROOT | NLM_F_MATCH)
+                                NLM_F_REQUEST | NLM_F_ROOT | NLM_F_MATCH, callback=udiag_tst_cb)

--- a/ss_tst.py
+++ b/ss_tst.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import inspect
+import json
+from pyroute2 import DiagSocket
+
+with DiagSocket() as ds:
+    ds.bind()
+    sstats = ds.get_sock_stats()
+
+    for stat in sstats:
+        #print inspect.getmembers(stat)
+        print stat.get['UDIAG_SHOW_PEER']
+
+#from socket import AF_INET
+#from pyroute2 import IPRoute
+
+## get access to the netlink socket
+#ip = IPRoute()
+
+## no monitoring here -- thus no bind()
+
+## print interfaces
+#print(ip.get_links())
+
+#print json.dumps(sstats, indent=4)


### PR DESCRIPTION
**Clarificiation ONLY PR** for why plain NLA extension to nlmsg is not enough in order to parse sk specific data although implemented this way in other NL interactions. Excuses for this hideous form of communicating this. Example here based on UNIX sks.

The data blob is definitly there, visible when introspecting. NLA's are not ending up in the attrs, though.

@svinota  Did a little deep dive into the nla_map compilation. Was this ever working? Would be striking if not, since heavily used this way. (see my tst script)  Seems all yours. Could you have look?



