### PR TITLE
Add setns syscall for s390

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -101,7 +101,8 @@ __NR = {'x86_': {'64bit': 308},
         'armv': {'32bit': 375},
         'aarc': {'32bit': 375,
                  '64bit': 268},  # FIXME: EABI vs. OABI?
-        'ppc6': {'64bit': 350}}
+        'ppc6': {'64bit': 350},
+        's390': {'64bit': 339}}
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 
 CLONE_NEWNET = 0x40000000


### PR DESCRIPTION
We need s390 support for creating network namespaces via pyroute2. Since OpenStack is exploiting pyroute2 [1], Neutron is broken on s390.

Would it be possible to trigger a release after this got merged? Thanks!

[1] https://github.com/openstack/neutron/commit/c4d4336e9ffc24b5d78691f0d45b3a5056c78330