### PR TITLE
Add s390x support

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/compat.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/compat.py
@@ -28,7 +28,7 @@ _BONDING_MASTER = '/sys/class/net/%s/master/ifindex'
 IFNAMSIZ = 16
 
 TUNDEV = '/dev/net/tun'
-if config.machine in ('i386', 'i686', 'x86_64'):
+if config.machine in ('i386', 'i686', 'x86_64', 's390x'):
     TUNSETIFF = 0x400454ca
     TUNSETPERSIST = 0x400454cb
     TUNSETOWNER = 0x400454cc

--- a/pyroute2/netlink/rtnl/ifinfmsg/proxy.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/proxy.py
@@ -27,7 +27,7 @@ _BONDING_MASTER = '/sys/class/net/%s/master/ifindex'
 IFNAMSIZ = 16
 
 TUNDEV = '/dev/net/tun'
-if config.machine in ('i386', 'i686', 'x86_64', 'armv6l', 'armv7l'):
+if config.machine in ('i386', 'i686', 'x86_64', 'armv6l', 'armv7l', 's390x'):
     TUNSETIFF = 0x400454ca
     TUNSETPERSIST = 0x400454cb
     TUNSETOWNER = 0x400454cc

--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -101,7 +101,8 @@ __NR = {'x86_': {'64bit': 308},
         'armv': {'32bit': 375},
         'aarc': {'32bit': 375,
                  '64bit': 268},  # FIXME: EABI vs. OABI?
-        'ppc6': {'64bit': 350}}
+        'ppc6': {'64bit': 350},
+        's390': {'64bit': 339}}
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 
 CLONE_NEWNET = 0x40000000


### PR DESCRIPTION
We need s390 support for creating network namespaces via pyroute2. Since OpenStack is exploiting pyroute2 [1], Neutron is broken on s390.

Would it be possible to trigger a release after this got merged? Thanks!

[1] openstack/neutron@c4d4336