### PR TITLE
(WIP) add nfconntrack count support

### DIFF
--- a/pyroute2/netlink/nfnetlink/conntrack.py
+++ b/pyroute2/netlink/nfnetlink/conntrack.py
@@ -36,6 +36,16 @@ IP_CT_TCP_FLAG_DATA_UNACKNOWLEDGED = 0x10
 # The field td_maxack has been set
 IP_CT_TCP_FLAG_MAXACK_SET = 0x20
 
+def terminate_single_msg(msg):
+    return msg
+
+
+class nfct_stats(nfgen_msg):
+    nla_map = (
+        ('CTA_STATS_GLOBAL_UNSPEC', 'none'),
+        ('CTA_STATS_GLOBAL_ENTRIES', 'be32'),
+    )
+
 
 class nfct_msg(nfgen_msg):
     nla_map = (
@@ -202,7 +212,7 @@ class NFCTSocket(NetlinkSocket):
         IPCTNL_MSG_CT_DELETE: nfct_msg,
         IPCTNL_MSG_CT_GET_CTRZERO: nfct_msg,
         IPCTNL_MSG_CT_GET_STATS_CPU: nfct_msg,
-        IPCTNL_MSG_CT_GET_STATS: nfct_msg,
+        IPCTNL_MSG_CT_GET_STATS: nfct_stats,
         IPCTNL_MSG_CT_GET_DYING: nfct_msg,
         IPCTNL_MSG_CT_GET_UNCONFIRMED: nfct_msg,
     }.items())
@@ -226,3 +236,16 @@ class NFCTSocket(NetlinkSocket):
 
         return self.request(msg, IPCTNL_MSG_CT_GET,
                             msg_flags=NLM_F_REQUEST | NLM_F_DUMP)
+
+    def count(self):
+        """ Return current number of conntrack entries
+
+        Same result than /proc/sys/net/netfilter/nf_conntrack_count file
+        or conntrack -C command
+        """
+        msg = nfct_stats()
+
+        ndmsg = self.request(msg, IPCTNL_MSG_CT_GET_STATS,
+                             msg_flags=NLM_F_REQUEST | NLM_F_DUMP,
+                             terminate=terminate_single_msg)
+        return ndmsg[0].get_attr('CTA_STATS_GLOBAL_ENTRIES')

--- a/pyroute2/netlink/nlsocket.py
+++ b/pyroute2/netlink/nlsocket.py
@@ -600,6 +600,7 @@ class NetlinkMixin(object):
                 bufsize = self.getsockopt(SOL_SOCKET, SO_RCVBUF) // 2
 
             ret = []
+            tmsg = None
             enough = False
             backlog_acquired = False
             try:
@@ -653,8 +654,11 @@ class NetlinkMixin(object):
 
                             # If it is the terminator message, say "enough"
                             # and requeue all the rest into Zero queue
-                            if (msg['header']['type'] == NLMSG_DONE) or \
-                                    (terminate is not None and terminate(msg)):
+                            if terminate is not None:
+                                tmsg = terminate(msg)
+                                if isinstance(tmsg, nlmsg):
+                                    ret.append(msg)
+                            if (msg['header']['type'] == NLMSG_DONE) or tmsg:
                                 # The loop is done
                                 enough = True
 


### PR DESCRIPTION
Hello,

This patch is a proof of context (not to merge) of nfconntrack count command.

However, this request return only one netlink message, without any "DONE" message. So it's not detected by pyroute2 and hang forever.

I tried to add a "terminate" condition, but it does not work since it skips matching messages. I checked code of conntrack tools, and it uses special code to match this command and get the single message.