### PR TITLE
Fix the file creation flag O_EXCL

### DIFF
--- a/pyroute2/netns/nslink.py
+++ b/pyroute2/netns/nslink.py
@@ -44,7 +44,7 @@ or uses existing one. To control this behaviour, one can use flags
 as for `open(2)` system call::
 
     # create a new netns or fail, if it already exists
-    netns = NetNS('test', flags=os.O_CREAT | os.O_EXIST)
+    netns = NetNS('test', flags=os.O_CREAT | os.O_EXCL)
 
     # create a new netns or use existing one
     netns = NetNS('test', flags=os.O_CREAT)


### PR DESCRIPTION
There's no flag named O_EXIST. It should be O_EXCL that ensures the call
fails if the namespace already exists.