### PR TITLE
nfnetlink: fix byte order of nfgen_msg.res_id field

### DIFF
--- a/pyroute2/netlink/nfnetlink/__init__.py
+++ b/pyroute2/netlink/nfnetlink/__init__.py
@@ -46,4 +46,4 @@ NFNLGRP_NFTRACE = 9
 class nfgen_msg(nlmsg):
     fields = (('nfgen_family', 'B'),
               ('version', 'B'),
-              ('res_id', 'H'))
+              ('res_id', '!H'))


### PR DESCRIPTION
The convention in nfnetlink is to use network byte order in every header field
except for old nft implementation on the ancient kernel.  Also recent kernel
provided a workaround for old nft, so now en/decoding res_id field as network
byte order seems safe:

  https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a9de9777d613500b089a7416f936bf3ae5f070d2