### PR TITLE
nfctsocket: add support for entry deletion

### DIFF
--- a/pyroute2/netlink/nfnetlink/nfctsocket.py
+++ b/pyroute2/netlink/nfnetlink/nfctsocket.py
@@ -268,8 +268,8 @@ class NFCTSocket(NetlinkSocket):
                             msg_flags=NLM_F_REQUEST | NLM_F_DUMP,
                             terminate=terminate_single_msg)
 
-    def flush(self, mark=None, mark_mask=0xffffffff, zone=None):
-        msg = self._mkmsg(mark=mark, mark_mask=mark_mask, zone=zone)
+    def flush(self, mark=None, mark_mask=0xffffffff):
+        msg = self._mkmsg(mark=mark, mark_mask=mark_mask)
         return self.request(msg, IPCTNL_MSG_CT_DELETE,
                             msg_flags=NLM_F_REQUEST | NLM_F_ACK)
 


### PR DESCRIPTION
Hi,

This PR adds support for conntrack entry deletion.  It provides pure mapping for kernel API.
If the delete function by "search and destroy" like conntrack command is needed, I believe conntrack module should provide it.

Thanks.
