### PR TITLE
Introduce "eventloop" style API to better handle netlink event storms

### DIFF
--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -704,6 +704,10 @@ import logging
 import traceback
 import threading
 import weakref
+try:
+    import queue
+except ImportError:
+    import Queue as queue  # The module is called 'Queue' in Python2
 
 from functools import partial
 from pprint import pprint
@@ -797,6 +801,8 @@ class IPDB(object):
         self._post_callbacks = {}
         self._pre_callbacks = {}
         self._cb_threads = {}
+        self._evq = None
+        self._evqdrop = 0
 
         # locks and events
         self.exclusive = threading.RLock()
@@ -1031,6 +1037,77 @@ class IPDB(object):
             t.join(3)
         ret = self._cb_threads.get(cuid, ())
         return ret
+
+    class _evq_context(object):
+        """
+        Context manager class for the event queue used by the event loop
+        """
+        def __init__(self, ipdb, qsize, block, timeout):
+            self._ipdb = ipdb
+            self._qsize = qsize
+            self._block = block
+            self._timeout = timeout
+
+        def __enter__(self):
+            with self._ipdb.exclusive:
+                self._ipdb._evq = queue.Queue(maxsize=self._qsize)
+                self._ipdb._evqdrop = 0
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            with self._ipdb.exclusive:
+                self._ipdb._evq = None
+                self._ipdb._evqdrop = 0
+                self._ipdb = None
+
+        def __del__(self):
+            if self._ipdb:
+                # Note: this should not happen if the class is used as a
+                # context manager. In case somebody initialized it
+                # directly, make sure that orphan event queue is not
+                # hanging in the ipdb instance after our instance is
+                # garbage collected.
+                with self._ipdb.exclusive:
+                    self._ipdb._evq = None
+                    self._ipdb._evqdrop = 0
+
+        def nextmsg(self):
+            if not self._ipdb:
+                raise RuntimeError('eventqueue must be used as context manager')
+            while True:
+                msg = self._ipdb._evq.get(self._block, self._timeout)
+                self._ipdb._evq.task_done()
+                # Mechanism for the monitoring thread to notify the processing
+                # thread(s) about an error condition.
+                if isinstance(msg, Exception):
+                    raise msg
+                yield msg
+
+    def eventqueue(self, qsize=8192, block=True, timeout=None):
+        """
+        Initializes event queue and returns event queue context manager.
+        Once the context manager is initialized, events start to be collected,
+        so it is possible to read initial state from the system witout losing
+        last moment changes, and once that is done, start processing events.
+
+        Example:
+
+            ipdb = IPDB()
+            with ipdb.eventqueue() as evq:
+                my_state = ipdb.<needed_attribute>...
+                for evq.nextmsg() as msg:
+                    update_state_by_msg(my_state, msg)
+        """
+        return self._evq_context(self, qsize, block, timeout)
+
+    def eventloop(self, qsize=8192, block=True, timeout=None):
+        """
+        Event generator for simple cases when there is no need for initial
+        state setup. Initialize event queue and yield events as they happen.
+        """
+        with self.eventqueue(qsize=qsize, block=block, timeout=timeout) as evq:
+            for msg in evq.nextmsg():
+                yield msg
 
     def release(self):
         '''
@@ -1334,6 +1411,14 @@ class IPDB(object):
                     if event in self._event_map:
                         for func in self._event_map[event]:
                             func(msg)
+                    if self._evq:
+                        try:
+                            self._evq.put_nowait(msg)
+                            if self._evqdrop:
+                                log.warning("dropped %d events", self._evqdrop)
+                            self._evqdrop = 0
+                        except queue.Full:
+                            self._evqdrop += 1
 
                 # run post-callbacks
                 # NOTE: post-callbacks are asynchronous

--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -1383,10 +1383,14 @@ class IPDB(object):
                 # anymore
                 if self._stop:
                     break
-            except:
-                log.error('Restarting IPDB instance after '
-                          'error:\n%s', traceback.format_exc())
+            except Exception as e:
+                with self.exclusive:
+                    if self._evq:
+                        self._evq.put(e)
+                        return
                 if self.restart_on_error:
+                    log.error('Restarting IPDB instance after '
+                              'error:\n%s', traceback.format_exc())
                     try:
                         self.initdb()
                     except:

--- a/pyroute2/netlink/nlsocket.py
+++ b/pyroute2/netlink/nlsocket.py
@@ -284,6 +284,8 @@ class NetlinkMixin(object):
                  port=None,
                  pid=None,
                  fileno=None,
+                 sndbuf=1048576,
+                 rcvbuf=1048576,
                  all_ns=False):
         #
         # That's a trick. Python 2 is not able to construct
@@ -308,6 +310,8 @@ class NetlinkMixin(object):
         self.fixed = True
         self.family = family
         self._fileno = fileno
+        self._sndbuf = sndbuf
+        self._rcvbuf = rcvbuf
         self.backlog = {0: []}
         self.callbacks = []     # [(predicate, callback, args), ...]
         self.pthread = None
@@ -911,8 +915,8 @@ class NetlinkSocket(NetlinkMixin):
                 def patch(data, bsize):
                     data[0:] = self._sock.recv(bsize)
                 self._sock.recv_into = patch
-            self.setsockopt(SOL_SOCKET, SO_SNDBUF, 1024 * 1024)
-            self.setsockopt(SOL_SOCKET, SO_RCVBUF, 1024 * 1024)
+            self.setsockopt(SOL_SOCKET, SO_SNDBUF, self._sndbuf)
+            self.setsockopt(SOL_SOCKET, SO_RCVBUF, self._rcvbuf)
             if self.all_ns:
                 self.setsockopt(SOL_NETLINK, NETLINK_LISTEN_ALL_NSID, 1)
 

--- a/pyroute2/netlink/rtnl/iprsocket.py
+++ b/pyroute2/netlink/rtnl/iprsocket.py
@@ -21,8 +21,10 @@ else:
 
 class IPRSocketMixin(object):
 
-    def __init__(self, fileno=None, all_ns=False):
+    def __init__(self, fileno=None, sndbuf=1048576, rcvbuf=1048576,
+                 all_ns=False):
         super(IPRSocketMixin, self).__init__(NETLINK_ROUTE, fileno=fileno,
+                                             sndbuf=sndbuf, rcvbuf=rcvbuf,
                                              all_ns=all_ns)
         self.marshal = MarshalRtnl()
         self._s_channel = None
@@ -44,7 +46,7 @@ class IPRSocketMixin(object):
             self.recv_ft = self._p_recv_ft
 
     def clone(self):
-        return type(self)()
+        return type(self)(sndbuf=self._sndbuf, rcvbuf=self._rcvbuf)
 
     def bind(self, groups=rtnl.RTMGRP_DEFAULTS, async=False):
         super(IPRSocketMixin, self).bind(groups, async=async)


### PR DESCRIPTION
Please consider this proposal.

In mass network topology updates, thousands of netlink packets lead to excessive resource usage (one thread per event use much memory and results in slow processing) and hanging process (recovery from failed IPDB commit is slow, and monitoring thread is prone to die without the master thread noticing).

This change allows the user to process incoming netlink messages in an event loop (in the main thread, or in any user-initiated thread(s)), and netlink socket receive errors are passed via the same queue, and re-raised in the master thread. This allows the user program to notice that netlink events where lost and take appropriate action.

The last commit of three allows to specify the size of netlink socket send and receive buffers, and thus control the "storm sensitivity" of the system.

Sidenote: on Linux, system wide max size of socket receive and send buffers is controlled with
/proc/sys/net/core/rmem_max, it may be worth to mention in the documentation.