### PR TITLE
Trivial style fix, indentation was wrong

### DIFF
--- a/pyroute2/ipdb/interfaces.py
+++ b/pyroute2/ipdb/interfaces.py
@@ -956,8 +956,8 @@ class Interface(Transactional):
                 self['ipaddr'].target.wait(SYNC_TIMEOUT)
                 if self['ipaddr'].target.is_set():
                     break
-            else:
-                raise CommitException('ipaddr target is not set')
+                else:
+                    raise CommitException('ipaddr target is not set')
 
             # 8<---------------------------------------------
             # Iterate callback chain


### PR DESCRIPTION
Indentation of a block is wrong. It works correctly, but makes
the code difficult to read.

Signed-off-by: Eugene Crosser <crosser@average.org>