### PR TITLE
Allow to perform active scanning.

### DIFF
--- a/pyroute2/iwutil.py
+++ b/pyroute2/iwutil.py
@@ -411,7 +411,7 @@ class IW(NL80211):
                          msg_type=self.prid,
                          msg_flags=NLM_F_REQUEST | NLM_F_ACK)
 
-    def scan(self, ifindex):
+    def scan(self, ifindex, ssids=None):
         '''
         Trigger scan and get results.
 
@@ -429,6 +429,12 @@ class IW(NL80211):
         msg = nl80211cmd()
         msg['cmd'] = NL80211_NAMES['NL80211_CMD_TRIGGER_SCAN']
         msg['attrs'] = [['NL80211_ATTR_IFINDEX', ifindex]]
+
+        # If a list of SSIDs is provided, active scanning should be performed
+        if ssids is not None:
+            if isinstance(ssids, list):
+                msg['attrs'].append(['NL80211_ATTR_SCAN_SSIDS', ssids])
+
         self.nlm_request(msg,
                          msg_type=self.prid,
                          msg_flags=NLM_F_REQUEST | NLM_F_ACK)

--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -232,7 +232,7 @@ class nl80211cmd(genlmsg):
                ('NL80211_ATTR_IE', 'hex'),
                ('NL80211_ATTR_MAX_NUM_SCAN_SSIDS', 'uint8'),
                ('NL80211_ATTR_SCAN_FREQUENCIES', 'hex'),
-               ('NL80211_ATTR_SCAN_SSIDS', 'hex'),
+               ('NL80211_ATTR_SCAN_SSIDS', '*string'),
                ('NL80211_ATTR_GENERATION', 'uint32'),
                ('NL80211_ATTR_BSS', 'bss'),
                ('NL80211_ATTR_REG_INITIATOR', 'hex'),


### PR DESCRIPTION
The `ssids` parameter has been added to the `scan()` method. This allows to perform active scanning when a list of SSIDs is provided.