### PR TITLE
Allow to flush the cache before scanning.

### DIFF
--- a/pyroute2/iwutil.py
+++ b/pyroute2/iwutil.py
@@ -140,6 +140,7 @@ from pyroute2.netlink.nl80211 import NL80211_NAMES
 from pyroute2.netlink.nl80211 import IFTYPE_NAMES
 from pyroute2.netlink.nl80211 import CHAN_WIDTH
 from pyroute2.netlink.nl80211 import BSS_STATUS_NAMES
+from pyroute2.netlink.nl80211 import SCAN_FLAGS_NAMES
 
 log = logging.getLogger(__name__)
 
@@ -481,7 +482,7 @@ class IW(NL80211):
                          msg_type=self.prid,
                          msg_flags=NLM_F_REQUEST | NLM_F_ACK)
 
-    def scan(self, ifindex, ssids=None):
+    def scan(self, ifindex, ssids=None, flush_cache=False):
         '''
         Trigger scan and get results.
 
@@ -504,6 +505,12 @@ class IW(NL80211):
         if ssids is not None:
             if isinstance(ssids, list):
                 msg['attrs'].append(['NL80211_ATTR_SCAN_SSIDS', ssids])
+
+        scan_flags = 0
+        if flush_cache:
+            # Flush the cache before scanning
+            scan_flags |= SCAN_FLAGS_NAMES['NL80211_SCAN_FLAG_FLUSH']
+            msg['attrs'].append(['NL80211_ATTR_SCAN_FLAGS', scan_flags])
 
         self.nlm_request(msg,
                          msg_type=self.prid,

--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -184,6 +184,17 @@ NL80211_BSS_STATUS_IBSS_JOINED = 2    # Joined to this IBSS
                                                       globals(),
                                                       normalize=True)
 
+NL80211_SCAN_FLAG_LOW_PRIORITY = 1 << 0
+NL80211_SCAN_FLAG_FLUSH = 1 << 1
+NL80211_SCAN_FLAG_AP = 1 << 2
+NL80211_SCAN_FLAG_RANDOM_ADDR = 1 << 3
+NL80211_SCAN_FLAG_FILS_MAX_CHANNEL_TIME = 1 << 4
+NL80211_SCAN_FLAG_ACCEPT_BCAST_PROBE_RESP = 1 << 5
+NL80211_SCAN_FLAG_OCE_PROBE_REQ_HIGH_TX_RATE = 1 << 6
+NL80211_SCAN_FLAG_OCE_PROBE_REQ_DEFERRAL_SUPPRESSION = 1 << 7
+(SCAN_FLAGS_NAMES, SCAN_FLAGS_VALUES) = map_namespace('NL80211_SCAN_FLAG_',
+                                                      globals())
+
 
 class nl80211cmd(genlmsg):
     prefix = 'NL80211_ATTR_'
@@ -345,7 +356,7 @@ class nl80211cmd(genlmsg):
                ('NL80211_ATTR_CONN_FAILED_REASON', 'hex'),
                ('NL80211_ATTR_SAE_DATA', 'hex'),
                ('NL80211_ATTR_VHT_CAPABILITY', 'hex'),
-               ('NL80211_ATTR_SCAN_FLAGS', 'hex'),
+               ('NL80211_ATTR_SCAN_FLAGS', 'uint32'),
                ('NL80211_ATTR_CHANNEL_WIDTH', 'uint32'),
                ('NL80211_ATTR_CENTER_FREQ1', 'uint32'),
                ('NL80211_ATTR_CENTER_FREQ2', 'uint32'),


### PR DESCRIPTION
Add a `flush_cache` parameter to the `scan()` method, in order to flush the cache before scanning.