### PR TITLE
Missing types (int8, int16, and int64) have been added.

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1543,12 +1543,33 @@ class nlmsg_atoms(nlmsg_base):
 
         fields = [('value', 'Q')]
 
+    class int8(nla_base):
+
+        __slots__ = ()
+        sql_type = 'INTEGER'
+
+        fields = [('value', 'b')]
+
+    class int16(nla_base):
+
+        __slots__ = ()
+        sql_type = 'INTEGER'
+
+        fields = [('value', 'h')]
+
     class int32(nla_base):
 
         __slots__ = ()
         sql_type = 'INTEGER'
 
         fields = [('value', 'i')]
+
+    class int64(nla_base):
+
+        __slots__ = ()
+        sql_type = 'INTEGER'
+
+        fields = [('value', 'q')]
 
     class be8(nla_base):
 


### PR DESCRIPTION
This PR adds missing types in `pyroute2/netlink/__init__.py`.

These are required in the code added in PR #514 