### PR TITLE
[WIP] Added work of tc-ematch/tc-basic

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/tcmsg/__init__.py
@@ -6,6 +6,7 @@ from pyroute2.netlink import nla
 from pyroute2.netlink.rtnl.tcmsg import cls_fw
 from pyroute2.netlink.rtnl.tcmsg import cls_u32
 from pyroute2.netlink.rtnl.tcmsg import cls_matchall
+from pyroute2.netlink.rtnl.tcmsg import cls_basic
 from pyroute2.netlink.rtnl.tcmsg import sched_bpf
 from pyroute2.netlink.rtnl.tcmsg import sched_choke
 from pyroute2.netlink.rtnl.tcmsg import sched_clsact
@@ -35,6 +36,7 @@ plugins = {'plug': sched_plug,
            'fw': cls_fw,
            'u32': cls_u32,
            'matchall': cls_matchall,
+           'basic': cls_basic,
            'ingress': sched_ingress,
            'pfifo_fast': sched_pfifo_fast,
            'choke': sched_choke,

--- a/pyroute2/netlink/rtnl/tcmsg/cls_basic.py
+++ b/pyroute2/netlink/rtnl/tcmsg/cls_basic.py
@@ -1,0 +1,75 @@
+import struct
+from socket import htons
+from pyroute2 import protocols
+from pyroute2.netlink import nla
+from pyroute2.netlink.rtnl.tcmsg.common_ematch import get_tcf_ematches
+from pyroute2.netlink.rtnl.tcmsg.common_ematch import nla_plus_tcf_ematch_opt
+
+def fix_msg(msg, kwarg):
+    if 'protocol' not in kwarg:
+        msg['info'] = htons(protocols.ETH_P_ALL & 0xffff) |\
+            ((kwarg.get('prio', 0) << 16) & 0xffff0000)
+    else:
+        msg['info'] = htons(kwarg.get('protocol', 0) & 0xffff) |\
+            ((kwarg.get('prio', 0) << 16) & 0xffff0000)
+
+
+def get_parameters(kwarg):
+    ret = {'attrs': []}
+    attrs_map = (
+        ('action', 'TCA_BASIC_ACT'),
+        ('classid', 'TCA_BASIC_CLASSID'),
+        #('match', 'TCA_BASIC_EMATCHES'),
+    )
+
+    if kwarg.get('match'):
+        ret['attrs'].append(['TCA_BASIC_EMATCHES', get_tcf_ematches(kwarg)])
+
+    for k, v in attrs_map:
+        r = kwarg.get(k, None)
+        if r is not None:
+            ret['attrs'].append([v, r])
+
+    return ret
+
+
+class options(nla):
+    nla_map = (('TCA_BASIC_UNSPEC', 'none'),
+               ('TCA_BASIC_CLASSID', 'uint32'),
+               ('TCA_BASIC_EMATCHES', 'parse_basic_ematch_tree'),
+               ('TCA_BASIC_ACT', 'hex'),
+               ('TCA_BASIC_POLICE', 'hex'),
+              )
+
+
+    class parse_basic_ematch_tree(nla):
+        nla_map = (('TCA_EMATCH_TREE_UNSPEC', 'none'),
+                   ('TCA_EMATCH_TREE_HDR', 'tcf_parse_header'),
+                   ('TCA_EMATCH_TREE_LIST', '*tcf_parse_list'),
+                  )
+
+
+        class tcf_parse_header(nla):
+            fields = (('nmatches', 'H'),
+                      ('progid', 'H'),
+                     )
+
+
+        class tcf_parse_list(nla, nla_plus_tcf_ematch_opt):
+            fields = (('matchid', 'H'),
+                      ('kind', 'H'),
+                      ('flags', 'H'),
+                      ('pad', 'H'),
+                     )
+
+            def decode(self):
+                nla.decode(self)
+                size = 0
+                for field in self.fields + self.header:
+                    size += struct.calcsize(field[1])
+
+                start = self.offset + size
+                end = start + (self.length - size)
+                data = self.data[start:end]
+                # TODO: it does not work :(
+                self['opt'] = self.parse_ematch_options(self, data)(data=data)

--- a/pyroute2/netlink/rtnl/tcmsg/common_ematch.py
+++ b/pyroute2/netlink/rtnl/tcmsg/common_ematch.py
@@ -1,0 +1,66 @@
+from pyroute2.netlink.rtnl.tcmsg import em_ipset
+
+plugins = {
+           #0: em_container,
+           #1: em_cmp,
+           #2: em_nbyte,
+           #3: em_u32,
+           #4: em_meta,
+           #5: em_text,
+           #6: em_vlan,
+           #7: em_canid,
+           8: em_ipset,
+           #9: em_ipt,
+          }
+
+plugins_translate = {
+                    'container': 0,
+                    'cmp': 1,
+                    'nbyte': 2,
+                    'u32': 3,
+                    'meta': 4,
+                    'text': 5,
+                    'vlan': 6,
+                    'canid': 7,
+                    'ipset': 8,
+                    'ipt': 9,
+                    }
+
+
+class nla_plus_tcf_ematch_opt(object):
+    @staticmethod
+    def parse_ematch_options(self, *argv, **kwarg):
+        if 'kind' not in self:
+            raise Exception('ematch requires "kind" parameter')
+
+        kind = self['kind']
+        if kind in plugins:
+            return plugins[kind].options
+        else:
+            return self.hex
+        return self.hex
+
+
+def get_ematch_parms(kwarg):
+    if 'kind' not in kwarg:
+        raise Exception('ematch requires "kind" parameter')
+
+    if kwarg['kind'] in plugins:
+        return plugins[kwarg['kind']].get_parameters(kwarg)
+    else:
+        return []
+
+
+def get_tcf_ematches(kwarg):
+    ret = {'attrs': []}
+
+    kind = kwarg['match'][0]['kind']
+
+    # Translate string kind into numeric kind
+    kind = plugins_translate[kind]
+
+    # Not sure if really needed
+    #ret['attrs'].append(['TCF_EM_KIND'], kind)
+
+    # Load plugin and transfer data
+    return plugins[kind].set_parameters(kwarg)

--- a/pyroute2/netlink/rtnl/tcmsg/em_ipset.py
+++ b/pyroute2/netlink/rtnl/tcmsg/em_ipset.py
@@ -1,0 +1,97 @@
+import struct
+from pyroute2.netlink import nla
+from pyroute2.netlink import nlmsg
+
+# see em_ipset.c
+IPSET_DIM = {
+    'IPSET_DIM_ZERO': 0,
+    'IPSET_DIM_ONE': 1,
+    'IPSET_DIM_TWO': 2,
+    'IPSET_DIM_THREE': 3,
+    'IPSET_DIM_MAX': 6,
+}
+
+TCF_EM_REL_END = 0
+TCF_EM_REL_AND = 1
+TCF_EM_REL_OR = 2
+TCF_EM_REL_MASK = 3
+TCF_EM_INVERT_MASK = 4
+TCF_EM_SIMPLE_PAYLOAD_MASK = 6
+TCF_EM_REL_VALID = lambda x : x & TCF_EM_REL_MASK != TCF_EM_REL_MASK
+TCF_EM_INVERT = lambda x : x & TCF_EM_INVERT_MASK == TCF_EM_INVERT_MASK
+TCF_EM_SIMPLE_PAYLOAD = lambda x : x & TCF_EM_SIMPLE_PAYLOAD_MASK == TCF_EM_SIMPLE_PAYLOAD_MASK
+
+TCF_IPSET_MODE_DST = 0
+TCF_IPSET_MODE_SRC = 2
+
+def get_parameters(kwarg):
+    ret = {'attrs': []}
+    attrs_map = (
+        ('matchid', 'TCF_EM_MATCHID'),
+        ('kind', 'TCF_EM_KIND'),
+        ('flags', 'TCF_EM_FLAGS'),
+        ('pad', 'TCF_EM_PAD'),
+        ('opt', 'TCF_IP_SET_OPT')
+    )
+
+    if 'flags' in kwarg:
+        flags = kwarg['flags']
+        if not TCF_EM_REL_VALID(flags):
+            raise Exception('Invalid relation flag')
+
+
+    opt = kwarg['opt']
+    format = 'HBB'
+
+    # Python struct hack because HBBI = 10 but HIBB = 8, Yay!
+    while len(opt) < struct.calcsize(format):
+        opt = opt + '\x00'
+
+    # See xt_set.h
+    res = struct.unpack(format, opt)
+    ip_set_index = res[0]
+    ip_set_flags = res[1]
+    ip_set_mode = res[2]
+
+
+    for k, v in attrs_map:
+        r = kwarg.get(k, None)
+        if r is not None:
+            ret['attrs'].append([v, r])
+
+    return ret
+
+
+def set_parameters(kwarg):
+    ret = {'attrs': []}
+
+    ip_set_name = kwarg['match'][0]['name']
+    ip_set_mode = kwarg['match'][0]['src']
+
+    # Translate IP set name to IP set index
+    ip_set_index = 3 #Cheater!
+
+    # Translate IP set mode
+    if ip_set_mode == 'dst':
+        ip_set_mode = 0
+    elif ip_set_mode == 'src':
+        ip_set_mode = 2
+    else:
+        raise Exception('Unknown IP set mode "{0}"'.format(ip_set_mode))
+
+    # Translate current relation
+    ip_set_relation = TCF_EM_REL_END #Cheater!
+
+    # Prepare value buffer
+
+
+class options(nla):
+    nla_map = (('TCF_IP_SET_OPT', 'parse_ip_set_options'),
+               )
+
+
+    class parse_ip_set_options(nlmsg):
+        fields = (('ip_set_index', 'H'),
+                  ('ip_set_flags', 'B'),
+                  ('ip_set_mode', 'B'),
+                  )


### PR DESCRIPTION
Hi @svinota,

we are working with @Vic063 on tc-ematch support. However, we didn't find the good way to parse a complex tc structure with pyroute2.

This pull request is not to merge, but to discuss to solve this issue before more work on our side. In short, tc-ematch sends through netlink a list of condition (TCA_EMATCH_TREE_LIST). Each member of the list has some common fields (matchid/kind/flags), and after that a "raw" data depending on the kind.

So we have several questions:

  * we are using the "*" star symbol before the tcf_parse_list n our nla_map. Is it the good way to do that with pyroute2? It's very rarely used in current code database
 * we tried to overwrite decode() method of tcf_parse_list class, to create an instance of ipset-ematch structure. But we are doing it wrong, since it does not work. The need is to read the kind, and to parse raw data after that


How to reproduce (we dump data with nldecap):

 * ipset create foo hash:ip
 * ip link add ifb0 type ifb
 * tc filter add dev ifb0 parent 1: basic match 'ipset(foo src)' classid 1:10 # one element in the list
 * tc filter add dev ifb0 parent 1: basic match 'ipset(foo src) and ipset(bar dst)' classid 1:10 # two elems

By the way, I found an old use of self.buf attribute in file pyroute2/netlink/rtnl/tcmsg/sched_fq_codel.py