### PR TITLE
rtmsg: Add mapping for ttl attribute in tunnelled mpls label

### DIFF
--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -156,7 +156,8 @@ class rtmsg_base(nlflags):
         __slots__ = ()
 
         nla_map = (('MPLS_IPTUNNEL_UNSPEC', 'none'),
-                   ('MPLS_IPTUNNEL_DST', 'mpls_target'))
+                   ('MPLS_IPTUNNEL_DST', 'mpls_target'),
+                   ('MPLS_IPTUNNEL_TTL', 'uint8'))
 
     class seg6_encap_info(nla):
 


### PR DESCRIPTION
Tunnelled/encapped mpls labels can also have a TTL attribute
passed with them. This was getting marked as unknown since it
didn't know how to parse it. Added the proper mapping.