### PR TITLE
Don't assume libc version

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -82,6 +82,7 @@ import os
 import os.path
 import errno
 import ctypes
+import ctypes.util
 import pickle
 import struct
 import traceback
@@ -140,7 +141,7 @@ def listnetns(nspath=None):
 
 
 def _create(netns, libc=None):
-    libc = libc or ctypes.CDLL('libc.so.6', use_errno=True)
+    libc = libc or ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
     netnspath = _get_netnspath(netns)
     netnsdir = os.path.dirname(netnspath)
 
@@ -205,7 +206,7 @@ def remove(netns, libc=None):
     '''
     Remove a network namespace.
     '''
-    libc = libc or ctypes.CDLL('libc.so.6', use_errno=True)
+    libc = libc or ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
     netnspath = _get_netnspath(netns)
     libc.umount2(netnspath, MNT_DETACH)
     os.unlink(netnspath)
@@ -225,7 +226,7 @@ def setns(netns, flags=os.O_CREAT, libc=None):
     not provided via arguments.
     '''
     newfd = False
-    libc = libc or ctypes.CDLL('libc.so.6', use_errno=True)
+    libc = libc or ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
     if isinstance(netns, basestring):
         netnspath = _get_netnspath(netns)
         if os.path.basename(netns) in listnetns(os.path.dirname(netns)):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ import errno
 import platform
 import subprocess
 import ctypes
+import ctypes.util
 from pyroute2 import NetlinkError
 from pyroute2 import IPRoute
 from nose.plugins.skip import SkipTest
@@ -265,7 +266,7 @@ def get_simple_bpf_program(prog_type):
     elif prog_type.lower() == "sched_act":
         attr = BPFAttr(BPF_PROG_TYPE_SCHED_ACT, len(insns),
                        insns, license, 0, 0, None, 0)
-    libc = ctypes.CDLL('libc.so.6')
+    libc = ctypes.CDLL(ctypes.util.find_library('c'))
     libc.syscall.argtypes = [ctypes.c_long, ctypes.c_int,
                              ctypes.POINTER(type(attr)), ctypes.c_uint]
     libc.syscall.restype = ctypes.c_int


### PR DESCRIPTION
While glibc is currently at version 6, there are other libc projects in
use which implement an older interface version, such as uClibc. Instead
of explicitly specifying the libc name, search for any libc that is
available.