### PR TITLE
Fix bug in seg6 encap decode(), add seg6local support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,43 @@ Some examples::
                     'segs':'2000::5,2000::6,2000::7,2000::8',
                     'hmac':0xf})
 
+    # create SEG6LOCAL tunnel End.DX4 action
+    # Kernel >= 4.14
+    ip.route('add',
+             dst='2001:0:0:10::2/128',
+             oif=idx,
+             encap={'type': 'seg6local',
+                    'action': 'End.DX4',
+                    'nh4': '172.16.0.10'})
+
+    # create SEG6LOCAL tunnel End.DT6 action
+    # Kernel >= 4.14
+    ip.route('add',
+             dst='2001:0:0:10::2/128',
+             oif=idx,
+             encap={'type': 'seg6local',
+                    'action': 'End.DT6',
+                    'table':'10'})
+
+    # create SEG6LOCAL tunnel End.B6 action
+    # Kernel >= 4.14
+    ip.route('add',
+             dst='2001:0:0:10::2/128',
+             oif=idx,
+             encap={'type': 'seg6local',
+                    'action': 'End.B6',
+                    'srh':{'segs': '2000::5,2000::6'}})
+
+    # create SEG6LOCAL tunnel End.B6 action with hmac
+    # Kernel >= 4.14
+    ip.route('add',
+             dst='2001:0:0:10::2/128',
+             oif=idx,
+             encap={'type': 'seg6local',
+                    'action': 'End.B6',
+                    'srh': {'segs': '2000::5,2000::6',
+                            'hmac':0xf}})
+
     # release Netlink socket
     ip.close()
 

--- a/pyroute2/netlink/rtnl/req.py
+++ b/pyroute2/netlink/rtnl/req.py
@@ -17,7 +17,8 @@ from pyroute2.netlink.rtnl.fibmsg import FR_ACT_NAMES
 encap_types = {'mpls': 1,
                AF_MPLS: 1,
                'seg6': 5,
-               'bpf': 6}
+               'bpf': 6,
+               'seg6local': 7}
 
 
 class IPRequest(dict):
@@ -195,6 +196,134 @@ class IPRouteRequest(IPRequest):
                         attrs['LWT_BPF_XMIT_HEADROOM'] = value['headroom']
 
             return {'attrs': attrs.items()}
+        '''
+        Seg6 encap header transform. Format samples:
+
+            {'type': 'seg6local',
+             'action': 'End.DT6',
+             'table': '10'}
+
+            {'type': 'seg6local',
+             'action': 'End.B6',
+             'table': '10'
+             'srh': {'segs': '2000::5,2000::6'}}
+        '''        
+        if header['type'] == 'seg6local':        
+            # Init step
+            ret = {}
+            table = None
+            nh4 = None
+            nh6 = None
+            iif = None  # Actually not used
+            oif = None
+            srh = {}
+            segs = []
+            hmac = None
+            # Parse segs
+            if srh:
+                segs = header['srh']['segs']
+                # If they are in the form in_addr6,in_addr6
+                if isinstance(segs, basestring):
+                    # Create an array with the splitted values
+                    temp = segs.split(',')
+                    # Init segs
+                    segs = []
+                    # Iterate over the values
+                    for seg in temp:
+                        # Discard empty string
+                        if seg != '':
+                            # Add seg to segs
+                            segs.append(seg)
+                # hmac is optional and contains the hmac key
+                hmac = header.get('hmac', None)
+            # Retrieve action
+            action = header['action']
+            if action == 'End.X':
+                # Retrieve nh6
+                nh6 = header['nh6']
+            elif action == 'End.T':
+                # Retrieve table and convert to u32
+                table = header['table'] & 0xffffffff
+            elif action == 'End.DX2':
+                # Retrieve oif and convert to u32
+                oif = header['oif'] & 0xffffffff
+            elif action == 'End.DX6':
+                # Retrieve nh6
+                nh6 = header['nh6']
+            elif action == 'End.DX4':
+                # Retrieve nh6
+                nh4 = header['nh4']
+            elif action == 'End.DT6':
+                # Retrieve table
+                table = header['table']
+            elif action == 'End.B6':
+                # Parse segs
+                segs = header['srh']['segs']
+                # If they are in the form in_addr6,in_addr6
+                if isinstance(segs, basestring):
+                    # Create an array with the splitted values
+                    temp = segs.split(',')
+                    # Init segs
+                    segs = []
+                    # Iterate over the values
+                    for seg in temp:
+                        # Discard empty string
+                        if seg != '':
+                            # Add seg to segs
+                            segs.append(seg)
+                # hmac is optional and contains the hmac key
+                hmac = header.get('hmac', None)
+                srh['segs'] = segs
+                # If hmac is present convert to u32
+                if hmac:
+                    # Add to ret the hmac key
+                    srh['hmac'] = hmac & 0xffffffff
+                srh['mode'] = 'inline'
+            elif action == 'End.B6.Encaps':
+                # Parse segs
+                segs = header['srh']['segs']
+                # If they are in the form in_addr6,in_addr6
+                if isinstance(segs, basestring):
+                    # Create an array with the splitted values
+                    temp = segs.split(',')
+                    # Init segs
+                    segs = []
+                    # Iterate over the values
+                    for seg in temp:
+                        # Discard empty string
+                        if seg != '':
+                            # Add seg to segs
+                            segs.append(seg)
+                # hmac is optional and contains the hmac key
+                hmac = header.get('hmac', None)
+                srh['segs'] = segs
+                if hmac:
+                    # Add to ret the hmac key
+                    srh['hmac'] = hmac & 0xffffffff
+                srh['mode'] = 'encap'
+            # Construct the new object
+            ret = []
+            ret.append(['SEG6_LOCAL_ACTION', {'value': action}])
+            if table:
+                # Add the table to ret
+                ret.append(['SEG6_LOCAL_TABLE', {'value': table}])
+            if nh4:
+                # Add the nh4 to ret
+                ret.append(['SEG6_LOCAL_NH4', {'value': nh4}])
+            if nh6:
+                # Add the nh6 to ret
+                ret.append(['SEG6_LOCAL_NH6', {'value': nh6}])
+            if iif:
+                # Add the iif to ret
+                ret.append(['SEG6_LOCAL_IIF', {'value': iif}])
+            if oif:
+                # Add the oif to ret
+                ret.append(['SEG6_LOCAL_OIF', {'value': oif}])
+            if srh:
+                # Add the srh to ret
+                ret.append(['SEG6_LOCAL_SRH', srh])
+            # Done return the object
+            return {'attrs': ret}
 
     def mpls_rta(self, value):
         ret = []
@@ -304,6 +433,31 @@ class IPRouteRequest(IPRequest):
                                      self.encap_header(value))
                 elif 'type' in value and ('in' in value or 'out' in value or
                                           'xmit' in value):
+                    dict.__setitem__(self, 'encap_type',
+                                     encap_types.get(value['type'],
+                                                     value['type']))
+                    dict.__setitem__(self, 'encap',
+                                     self.encap_header(value))
+                # human-friendly form:
+                #
+                # 'encap': {'type': 'seg6local',
+                #           'action': 'End'}
+                #
+                # 'encap': {'type': 'seg6local',
+                #           'action': 'End.DT6',
+                #           'table': '10'}
+                #
+                # 'encap': {'type': 'seg6local',
+                #           'action': 'End.DX6',
+                #           'nh6': '2000::5'}
+                #
+                # 'encap': {'type': 'seg6local',
+                #           'action': 'End.B6'
+                #           'srh': {'segs': '2000::5,2000::6',
+                #                   'hmac': 0xf}}
+                #
+                # 'type' and 'action' are mandatory
+                elif 'type' in value and 'action' in value:
                     dict.__setitem__(self, 'encap_type',
                                      encap_types.get(value['type'],
                                                      value['type']))

--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -192,6 +192,9 @@ class rtmsg_base(nlflags):
                 "encap": SEG6_IPTUN_MODE_ENCAP
             }
 
+            # Reverse mapping: mapping nla value to string
+            r_encapmodes = {v : k for k, v in encapmodes.iteritems()}
+
             # Nla value for seg6 type
             SEG6_TYPE = 4
 
@@ -281,6 +284,9 @@ class rtmsg_base(nlflags):
             def decode(self):
                 # Decode the data
                 nla.decode(self)
+                # Extract the encap mode
+                self['mode'] = (self.r_encapmodes
+                                .get(self['encapmode'], "encap"))
                 # Calculate offset of the segs
                 offset = self.offset + 16
                 # Point the addresses
@@ -325,12 +331,287 @@ class rtmsg_base(nlflags):
                        ('LWT_BPF_PROG_FD', 'uint32'),
                        ('LWT_BPF_PROG_NAME', 'asciiz'))
 
+    class seg6local_encap_info(nla):
+
+        __slots__ = ()
+
+        nla_map = (('SEG6_LOCAL_UNSPEC', 'none'),
+                   ('SEG6_LOCAL_ACTION', 'action'),
+                   ('SEG6_LOCAL_SRH', 'ipv6_sr_hdr'),
+                   ('SEG6_LOCAL_TABLE', 'table'),
+                   ('SEG6_LOCAL_NH4', 'nh4'),
+                   ('SEG6_LOCAL_NH6', 'nh6'),
+                   ('SEG6_LOCAL_IIF', 'iif'),
+                   ('SEG6_LOCAL_OIF', 'oif'),
+                   ('SEG6_LOCAL_BPF', 'none'))  # Actually not used
+
+        class ipv6_sr_hdr(nla):
+
+            __slots__ = ()
+
+            fields = (('nexthdr', 'B'),
+                      ('hdrlen', 'B'),
+                      ('type', 'B'),
+                      ('segments_left', 'B'),
+                      ('first_segment', 'B'),
+                      ('flags', 'B'),
+                      ('reserved', 'H'),
+                      ('segs', 's'),
+                      # Potentially several type-length-value
+                      ('tlvs', 's'))
+
+            # Corresponding values for seg6 encap modes
+            SEG6_IPTUN_MODE_INLINE = 0
+            SEG6_IPTUN_MODE_ENCAP = 1
+
+            # Mapping string to nla value
+            encapmodes = {
+                "inline": SEG6_IPTUN_MODE_INLINE,
+                "encap": SEG6_IPTUN_MODE_ENCAP
+            }
+
+            # Reverse mapping: mapping nla value to string
+            r_encapmodes = {v : k for k, v in encapmodes.iteritems()}
+
+            # Nla value for seg6 type
+            SEG6_TYPE = 4
+
+            # Flag value for hmac
+            SR6_FLAG1_HMAC = 1 << 3
+
+            # Tlv value for hmac
+            SR6_TLV_HMAC = 5
+
+            # Utility function to get the family from the msg
+            def get_family(self):
+                pointer = self
+                while pointer.parent is not None:
+                    pointer = pointer.parent
+                return pointer.get('family', AF_UNSPEC)
+
+            def encode(self):
+                # Retrieve the family
+                family = self.get_family()
+                # Seg6 can be applied only to IPv6
+                if family == AF_INET6:
+                    # Get mode
+                    mode = self['mode']
+                    # Get segs
+                    segs = self['segs']
+                    # Get hmac
+                    hmac = self.get('hmac', None)
+                    # With "inline" mode there is not
+                    # encap into an outer IPv6 header
+                    if mode == "inline":
+                        # Add :: to segs
+                        segs.insert(0, "::")
+                    # Add mode to value
+                    self['encapmode'] = (self
+                                         .encapmodes
+                                         .get(mode,
+                                              self.SEG6_IPTUN_MODE_ENCAP))
+                    # Calculate srlen
+                    srhlen = 8 + 16 * len(segs)
+                    # If we are using hmac we have a tlv as trailer data
+                    if hmac:
+                        # Since we can use sha1 or sha256
+                        srhlen += 40
+                    # Calculate and set hdrlen
+                    self['hdrlen'] = (srhlen >> 3) - 1
+                    # Add seg6 type
+                    self['type'] = self.SEG6_TYPE
+                    # Add segments left
+                    self['segments_left'] = len(segs) - 1
+                    # Add fitst segment
+                    self['first_segment'] = len(segs) - 1
+                    # If hmac is used we have to set the flags
+                    if hmac:
+                        # Add SR6_FLAG1_HMAC
+                        self['flags'] |= self.SR6_FLAG1_HMAC
+                    # Init segs
+                    self['segs'] = b''
+                    # Iterate over segments
+                    for seg in segs:
+                        # Convert to network byte order and add to value
+                        self['segs'] += inet_pton(family, seg)
+                    # Initialize tlvs
+                    self['tlvs'] = b''
+                    # If hmac is used we have to properly init tlvs
+                    if hmac:
+                        # Put type
+                        self['tlvs'] += struct.pack('B', self.SR6_TLV_HMAC)
+                        # Put length -> 40-2
+                        self['tlvs'] += struct.pack('B', 38)
+                        # Put reserved
+                        self['tlvs'] += struct.pack('H', 0)
+                        # Put hmac key
+                        self['tlvs'] += struct.pack('>I', hmac)
+                        # Put hmac
+                        self['tlvs'] += struct.pack('QQQQ', 0, 0, 0, 0)
+                else:
+                    raise TypeError('Family %s not supported for seg6 tunnel'
+                                    % family)
+                # Finally encode as nla
+                nla.encode(self)
+
+            # Utility function to verify if hmac is present
+            def has_hmac(self):
+                # Useful during the decoding
+                return self['flags'] & self.SR6_FLAG1_HMAC
+            
+            def decode(self):
+                # Decode the data
+                nla.decode(self)
+                # Extract the encap mode
+                self['mode'] = (self.r_encapmodes
+                                .get(self['encapmode'], "encap"))
+                # Calculate offset of the segs
+                offset = self.offset + 16
+                # Point the addresses
+                addresses = self.data[offset:]
+                # Extract the number of segs
+                n_segs = self['segments_left'] + 1
+                # Init segs
+                segs = []
+                # Move 128 bit in each step
+                for i in range(n_segs):
+                    # Save the segment
+                    segs.append(inet_ntop(AF_INET6,
+                                          addresses[i * 16:i * 16 + 16]))
+                # Save segs
+                self['segs'] = segs
+                # Init tlvs
+                self['tlvs'] = ''
+                # If hmac is used
+                if self.has_hmac():
+                    # Point to the start of hmac
+                    hmac = addresses[n_segs * 16:n_segs * 16 + 40]
+                    # Save tlvs section
+                    self['tlvs'] = hexdump(hmac)
+                    # Show also the hmac key
+                    self['hmac'] = hexdump(hmac[4:8])
+
+        class table(nla):
+
+          __slots__ = ()
+          
+          # Table ID
+          fields = (('value', 'I'),)
+
+        class action(nla):
+
+            __slots__ = ()
+
+            # Action
+            fields = (('value', 'I'),)
+
+            SEG6_LOCAL_ACTION_UNSPEC = 0
+            SEG6_LOCAL_ACTION_END     = 1
+            SEG6_LOCAL_ACTION_END_X   = 2
+            SEG6_LOCAL_ACTION_END_T   = 3
+            SEG6_LOCAL_ACTION_END_DX2   = 4
+            SEG6_LOCAL_ACTION_END_DX6   = 5
+            SEG6_LOCAL_ACTION_END_DX4   = 6
+            SEG6_LOCAL_ACTION_END_DT6   = 7
+            SEG6_LOCAL_ACTION_END_DT4   = 8
+            SEG6_LOCAL_ACTION_END_B6    = 9
+            SEG6_LOCAL_ACTION_END_B6_ENCAP  = 10
+            SEG6_LOCAL_ACTION_END_BM    = 11
+            SEG6_LOCAL_ACTION_END_S   = 12
+            SEG6_LOCAL_ACTION_END_AS    = 13
+            SEG6_LOCAL_ACTION_END_AM    = 14
+            SEG6_LOCAL_ACTION_END_BPF   = 15
+
+            actions = {
+              'End': SEG6_LOCAL_ACTION_END,
+              'End.X': SEG6_LOCAL_ACTION_END_X,
+              'End.T': SEG6_LOCAL_ACTION_END_T,
+              'End.DX2': SEG6_LOCAL_ACTION_END_DX2,
+              'End.DX6': SEG6_LOCAL_ACTION_END_DX6,
+              'End.DX4': SEG6_LOCAL_ACTION_END_DX4,
+              'End.DT6': SEG6_LOCAL_ACTION_END_DT6,
+              'End.DT4': SEG6_LOCAL_ACTION_END_DT4,
+              'End.B6': SEG6_LOCAL_ACTION_END_B6,
+              'End.B6.Encaps': SEG6_LOCAL_ACTION_END_B6_ENCAP,
+              'End.BM': SEG6_LOCAL_ACTION_END_BM,
+              'End.S': SEG6_LOCAL_ACTION_END_S,
+              'End.AS': SEG6_LOCAL_ACTION_END_AS,
+              'End.AM': SEG6_LOCAL_ACTION_END_AM,
+              'End.BPF': SEG6_LOCAL_ACTION_END_BPF
+            }
+            
+            def encode(self):
+              # Get action type and convert string to value
+              action = self['value']
+              self['value'] = (self
+                                 .actions
+                                 .get(action,
+                                      self.SEG6_LOCAL_ACTION_UNSPEC))
+              # Convert action type to u32
+              self['value'] = self['value'] & 0xffffffff
+              # Finally encode as nla
+              nla.encode(self)
+
+        class iif(nla):
+
+            __slots__ = ()
+
+            # Index of the incoming interface
+            fields = (('value', 'I'),)
+        
+        class oif(nla):
+
+            __slots__ = ()
+
+            # Index of the outcoming interface
+            fields = (('value', 'I'),)
+
+        class nh4(nla):
+
+            __slots__ = ()
+
+            # Nexthop of the IPv4 family
+            fields = (('value', 's'),)
+            
+            def encode(self):
+              # Convert to network byte order
+              self['value'] = inet_pton(AF_INET, self['value']) 
+              # Finally encode as nla
+              nla.encode(self)
+
+            def decode(self):
+              # Decode the data
+              nla.decode(self)
+              # Convert the packed IP address to its string representation
+              self['value'] = inet_ntop(AF_INET,
+                                        self['value'])
+
+        class nh6(nla):
+
+            __slots__ = ()
+
+            # Nexthop of the IPv6 family
+            fields = (('value', 's'),)
+            
+            def encode(self):
+              # Convert to network byte order
+              self['value'] = inet_pton(AF_INET6, self['value']) 
+              # Finally encode as nla
+              nla.encode(self)
+
+            def decode(self):
+              # Decode the data
+              nla.decode(self)
+              # Convert the packed IP address to its string representation
+              self['value'] = inet_ntop(AF_INET6, self['value'])
+
     #
     # TODO: add here other lwtunnel types
     #
     encaps = {LWTUNNEL_ENCAP_MPLS: mpls_encap_info,
               LWTUNNEL_ENCAP_SEG6: seg6_encap_info,
-              LWTUNNEL_ENCAP_BPF: bpf_encap_info}
+              LWTUNNEL_ENCAP_BPF: bpf_encap_info,
+              LWTUNNEL_ENCAP_SEG6_LOCAL: seg6local_encap_info}
 
     class rta_mfc_stats(nla):
 


### PR DESCRIPTION
Changes:
- Fix bug in seg6 decode(): flush_routes() give an error when it tried to delete all the routes because encapmode field was not decoded
- Introduces IPRoute support for seg6local tunnel
- Adds behaviours: End, End.X, End.T, End.DX2, End.DX6, End.DX4, End.DT6, End.B6, End.B6.Encaps
- Supports hmac functionality for SRH
- Initial parsing of human friendly form