### PR TITLE
Replace "iteritems" with "items"

### DIFF
--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -193,7 +193,7 @@ class rtmsg_base(nlflags):
             }
 
             # Reverse mapping: mapping nla value to string
-            r_encapmodes = {v: k for k, v in encapmodes.iteritems()}
+            r_encapmodes = {v: k for k, v in encapmodes.items()}
 
             # Nla value for seg6 type
             SEG6_TYPE = 4
@@ -371,7 +371,7 @@ class rtmsg_base(nlflags):
             }
 
             # Reverse mapping: mapping nla value to string
-            r_encapmodes = {v: k for k, v in encapmodes.iteritems()}
+            r_encapmodes = {v: k for k, v in encapmodes.items()}
 
             # Nla value for seg6 type
             SEG6_TYPE = 4


### PR DESCRIPTION
Replace Python2 dict.iteritems() with Py2/Py3 dict.items(),
to avoid Python3 errors.