### PR TITLE
rtnl: Add Support for XFRM Interfaces

### DIFF
--- a/pyroute2/ipdb/main.py
+++ b/pyroute2/ipdb/main.py
@@ -1317,7 +1317,7 @@ class IPDB(object):
             # intefaces
             kind = target.get('kind', None)
             if kind in ('vlan', 'vxlan', 'gre', 'tuntap', 'vti', 'vti6',
-                        'vrf'):
+                        'vrf', 'xfrm'):
                 tx_prio1.append((target, tx))
             elif kind in ('bridge', 'bond'):
                 tx_prio2.append((target, tx))

--- a/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
@@ -22,7 +22,8 @@ from pyroute2.netlink.rtnl.ifinfmsg.plugins import (bond,
                                                     vrf,
                                                     vti,
                                                     vti6,
-                                                    vxlan)
+                                                    vxlan,
+                                                    xfrm)
 
 log = logging.getLogger(__name__)
 
@@ -217,7 +218,8 @@ for module in (bond,
                vrf,
                vti,
                vti6,
-               vxlan):
+               vxlan,
+               xfrm):
     name = module.__name__.split('.')[-1]
     data_plugins[name] = getattr(module, name)
 

--- a/pyroute2/netlink/rtnl/ifinfmsg/plugins/xfrm.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/plugins/xfrm.py
@@ -1,0 +1,7 @@
+from pyroute2.netlink import nla
+
+
+class xfrm(nla):
+    nla_map = (('IFLA_XFRM_UNSPEC', 'none'),
+               ('IFLA_XFRM_LINK', 'uint32'),
+               ('IFLA_XFRM_IF_ID', 'uint32'))

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -408,6 +408,18 @@ class TestIPRoute(object):
                      vti_ikey=80,
                      vti_okey=88)
 
+    def test_create_xfrm(self):
+        require_user('root')
+        # XXX: Currently does not work on top of a dummy device
+        idx = self.ip.link_lookup(ifname='lo')[0]
+        # # Create Dummy for Parent
+        # (_, idx) = self.create()
+        self.ip.link('set', index=idx, state='up')
+        # Create XFRM Interface on It
+        self._create('xfrm',
+                     xfrm_link=idx,
+                     xfrm_if_id=555)
+
     def test_ntables(self):
         setA = set(filter(lambda x: x is not None,
                           [x.get_attr('NDTA_PARMS').get_attr('NDTPA_IFINDEX')


### PR DESCRIPTION
Virtual XFRM interfaces are available in Kernel 4.19+

Signed-off-by: Matt Ellison <matt@arroyo.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/svinota/pyroute2/572)
<!-- Reviewable:end -->
