### PR TITLE
Stop NetNS server gracefully

### DIFF
--- a/pyroute2/netns/nslink.py
+++ b/pyroute2/netns/nslink.py
@@ -167,6 +167,8 @@ class NetNS(RTNL_API, RemoteSocket):
                 os._exit(0)
 
         try:
+            self.remote_trnsp_in.close()
+            self.remote_trnsp_out.close()
             super(NetNS, self).__init__(trnsp_in, trnsp_out)
         except Exception:
             self.close()
@@ -197,18 +199,9 @@ class NetNS(RTNL_API, RemoteSocket):
             except Exception:
                 pass
             log.error('forced shutdown procedure, clean up netns manually')
-        # force cleanup command channels
-        for close in (self.trnsp_in.close,
-                      self.trnsp_out.close,
-                      self.remote_trnsp_in.close,
-                      self.remote_trnsp_out.close):
-            try:
-                close()
-            except Exception:
-                pass  # Maybe already closed in remote.Client.close
 
         try:
-            os.kill(self.child, signal.SIGKILL)
+            os.kill(self.child, signal.SIGTERM)
             os.waitpid(self.child, 0)
         except OSError:
             pass


### PR DESCRIPTION
This patch changes the way of stopping the NetNS server, by sending
a SIGTERM signal and waiting for the server loop to finish. When the
signal is received, the loop control flag is inverted. Once the loop
is finished, the server process ends.

This patch also modifies the Transport class receiver function loops.
When the Transport object is closed, the receiver loops are stopped but
not the file descriptors. Those file descriptors, created in the NetNS
parent class, are closed at the end of the NetNS.close function, once
the child process (Server) is finished and the Transport receiver loops
are stopped. At this point, the file descriptors are not in use and can
be closed.