### PR TITLE
iproute: add support of NOARP flag

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -58,6 +58,7 @@ from pyroute2.netlink.rtnl import ndmsg
 from pyroute2.netlink.rtnl.ndtmsg import ndtmsg
 from pyroute2.netlink.rtnl.fibmsg import fibmsg
 from pyroute2.netlink.rtnl.ifinfmsg import ifinfmsg
+from pyroute2.netlink.rtnl.ifinfmsg import IFF_NOARP
 from pyroute2.netlink.rtnl.ifaddrmsg import ifaddrmsg
 from pyroute2.netlink.rtnl.iprsocket import IPRSocket
 from pyroute2.netlink.rtnl.iprsocket import IPBatchSocket
@@ -1140,6 +1141,12 @@ class RTNL_API(object):
             if kwarg['state'].lower() == 'up':
                 flags = 1             # 0 (down) or 1 (up)
             del kwarg['state']
+
+        # arp on/off shortcut
+        if 'arp' in kwarg:
+            mask |= IFF_NOARP
+            if not kwarg.pop('arp'):
+                flags |= IFF_NOARP
 
         msg['flags'] = flags
         msg['change'] = mask

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -10,6 +10,7 @@ from pyroute2.common import AF_MPLS
 from pyroute2.netlink import nlmsg
 from pyroute2.netlink.rtnl.req import IPRouteRequest
 from pyroute2.netlink.rtnl.ifinfmsg import ifinfmsg
+from pyroute2.netlink.rtnl.ifinfmsg import IFF_NOARP
 from pyroute2.netlink.rtnl.rtmsg import RTNH_F_ONLINK
 from utils import grep
 from utils import require_user
@@ -1147,6 +1148,15 @@ class TestIPRoute(object):
         except NetlinkError:
             pass
         assert len(self.ip.link_lookup(ifname=self.dev)) == 1
+
+    def test_link_arp_flag(self):
+        dev = self.ifaces[0]
+        # by default dummy interface have NOARP set
+        assert self.ip.get_links(dev)[0]['flags'] & IFF_NOARP
+        self.ip.link('set', index=dev, arp=True)
+        assert not self.ip.get_links(dev)[0]['flags'] & IFF_NOARP
+        self.ip.link('set', index=dev, arp=False)
+        assert self.ip.get_links(dev)[0]['flags'] & IFF_NOARP
 
     def test_rules(self):
         assert len(get_ip_rules('-4')) == \


### PR DESCRIPTION
NOARP is only a flag, that one can set with sysfs (with
/sys/class/net/<dev>/flags file) or using interface flag with netlink.

This commit adds a helper to mimic ip commands:
 * ip link set arp on dev <dev>
 * ip link set arp off dev <dev>

It's now possible to do:
 ip.link('set', arp=True, index=ifindex)
 ip.link('set', arp=False, index=ifindex)