### PR TITLE
cls_fw: set default protocol to ETH_P_ALL when not specified

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/cls_fw.py
+++ b/pyroute2/netlink/rtnl/tcmsg/cls_fw.py
@@ -1,4 +1,5 @@
 from socket import htons
+from pyroute2 import protocols
 from pyroute2.netlink import nla
 from pyroute2.netlink.rtnl.tcmsg.act_police import nla_plus_police
 from pyroute2.netlink.rtnl.tcmsg.act_police import get_parameters \
@@ -6,7 +7,7 @@ from pyroute2.netlink.rtnl.tcmsg.act_police import get_parameters \
 
 
 def fix_msg(msg, kwarg):
-    msg['info'] = htons(kwarg.get('protocol', 0) & 0xffff) |\
+    msg['info'] = htons(kwarg.get('protocol', protocols.ETH_P_ALL) & 0xffff) |\
         ((kwarg.get('prio', 0) << 16) & 0xffff0000)
 
 


### PR DESCRIPTION
When using the following command, it automatically sets the ethernet protocol to 'all':
`tc filter add dev ifb0 handle 25 fw classid 1:12`

> root@pc-dev:~# tc filter show dev ifb0
> filter parent 1: protocol all pref 49150 fw 
> filter parent 1: protocol all pref 49150 fw handle 0x19 classid 1:12

This patch permits to call tc from pyroute2 and create a tc-fw filter without specifying the protocol to use.