### PR TITLE
netns: add documentation on how to go back on default netns

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -222,6 +222,11 @@ def setns(netns, flags=os.O_CREAT, libc=None):
         - O_CREAT -- create netns, if doesn't exist
         - O_CREAT | O_EXCL -- create only if doesn't exist
 
+    Note that "main" netns as no name. But you can access it with::
+
+        setns('foo')  # move to netns foo
+        setns('/proc/1/ns/net')  # go back to default netns
+
     Changed in 0.5.1: the routine closes the ns fd if it's
     not provided via arguments.
     '''


### PR DESCRIPTION
Hello,

I didn't find any reference in the documentation for this annoying thing. There is perhaps a better way, but in all cases I think that it's a good idea to add documentation on it.