### PR TITLE
Wiset replace update

### DIFF
--- a/pyroute2/wiset.py
+++ b/pyroute2/wiset.py
@@ -340,7 +340,10 @@ class WiSet(object):
     def insert_list(self, entries):
         """ Just a small helper to reduce the number of loops in main code. """
         for entry in entries:
-            self.add(entry)
+            if isinstance(entry, basestring):
+                self.add(entry)
+            elif isinstance(entry, dict):
+                self.add(**entry)
 
     def replace_entries(self, new_list):
         """ Replace the content of an ipset with a new list of entries.
@@ -349,7 +352,8 @@ class WiSet(object):
         this call is atomic: it creates a temporary ipset and swap the content.
 
         :param new_list: list of entries to add
-        :type new_list: list or :py:class:`set`
+        :type new_list: list or :py:class:`set` of basestring or of
+        keyword arguments dict
         """
         temp_name = str(uuid.uuid4())[0:8]
         # Get a copy of ourself

--- a/pyroute2/wiset.py
+++ b/pyroute2/wiset.py
@@ -39,6 +39,7 @@ from pyroute2.common import basestring
 from pyroute2.netlink.exceptions import IPSetError
 from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_COUNTERS
 from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_COMMENT
+from pyroute2.netlink.nfnetlink.ipset import IPSET_FLAG_WITH_SKBINFO
 
 
 # Debug variable to detect netlink socket leaks
@@ -197,6 +198,7 @@ class WiSet(object):
         if flags is not None:
             self.counters = bool(flags & IPSET_FLAG_WITH_COUNTERS)
             self.comment = bool(flags & IPSET_FLAG_WITH_COMMENT)
+            self.skbinfo = bool(flags & IPSET_FLAG_WITH_SKBINFO)
 
         if content:
             self.update_dict_content(ndmsg)

--- a/tests/general/test_wiset.py
+++ b/tests/general/test_wiset.py
@@ -209,6 +209,34 @@ class WiSet_test(object):
         test_replace(list_a, list_b)
         test_replace(set(list_a), set(list_b))
 
+    def test_replace_content_with_comment(self, sock=None):
+        require_user('root')
+        list_a = [{'entry': "1.2.3.4", 'comment': 'foo'},
+                  {'entry': "2.3.4.5", 'comment': 'foo'},
+                  {'entry': "6.7.8.9", 'comment': 'bar'}]
+        list_b = [{'entry': "1.1.1.1", 'comment': 'foo'},
+                  {'entry': "2.2.2.2", 'comment': 'bar'},
+                  {'entry': "3.3.3.3", 'comment': 'foo'}]
+
+        def test_replace(content_a, content_b):
+            myset = WiSet(name=self.name, sock=sock, comment=True)
+            myset.create()
+            myset.insert_list(content_a)
+            myset.update_content()
+            for value in content_a:
+                assert value['entry'] in myset.content
+                assert value['comment'] == myset.content[value['entry']].comment
+            myset.replace_entries(content_b)
+            myset.update_content()
+            for value in content_a:
+                assert value['entry'] not in myset.content
+            for value in content_b:
+                assert value['entry'] in myset.content
+                assert value['comment'] == myset.content[value['entry']].comment
+            myset.destroy()
+
+        test_replace(list_a, list_b)
+
     def test_hash_net_ipset(self, sock=None):
         require_user('root')
         to_add = ["192.168.1.0/24", "192.168.2.0/23", "10.0.0.0/8"]


### PR DESCRIPTION
Hello,

This pull request add the support of kwargs list for the replace_entries method of wiset in addition to a basestring list.
This allow to use this "atomic" operation to replace the content of an ipset having skbinfo or comments
I also added a test for it.

Best regards

Charles