### PR TITLE
NetNS: get netns name by PID

### DIFF
--- a/tests/general/test_netns.py
+++ b/tests/general/test_netns.py
@@ -425,8 +425,10 @@ class TestNetNS(object):
         netnsmod.popns()
 
         pids = netnsmod.ns_pids()
+        ns_name = netnsmod.pid_to_ns(foo_pid)
         try:
             assert pids[foo] == [foo_pid]
+            assert ns_name == foo
         finally:
             os.close(foo_fd)
             netnsmod.remove(foo)


### PR DESCRIPTION
Add function to get netns name associated to a PID if it exists.