### PR TITLE
Add support for IPoIB interface

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -1167,6 +1167,30 @@ class RTNL_API(object):
         All possible vxlan parameters are listed in the module
         `pyroute2.netlink.rtnl.ifinfmsg:... vxlan_data`.
 
+        ► ipoib
+
+        IPoIB driver provides an ability to create several ip interfaces
+        on one interface.
+        IPoIB interfaces requires the following parameter:
+
+        `link` : The master interface to create IPoIB on.
+
+        The following parameters can also be provided:
+
+        `pkey` : Inifiniband partition key the ip interface is associated with
+        `mode` : Underlying infiniband transport mode.
+                 One of:  ['datagram' ,'connected']
+        `umcast` : If set(1), multicast group membership for this interface is
+                   handled by user space.
+
+        Example::
+
+            ip.link("add",
+                    ifname="ipoib1",
+                    kind="ipoib",
+                    link=ip.link_lookup(ifname="ib0")[0],
+                    pkey=10)
+
         **set**
 
         Set interface attributes::

--- a/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
@@ -23,7 +23,8 @@ from pyroute2.netlink.rtnl.ifinfmsg.plugins import (bond,
                                                     vti,
                                                     vti6,
                                                     vxlan,
-                                                    xfrm)
+                                                    xfrm,
+                                                    ipoib)
 
 log = logging.getLogger(__name__)
 
@@ -219,7 +220,8 @@ for module in (bond,
                vti,
                vti6,
                vxlan,
-               xfrm):
+               xfrm,
+               ipoib):
     name = module.__name__.split('.')[-1]
     data_plugins[name] = getattr(module, name)
 

--- a/pyroute2/netlink/rtnl/ifinfmsg/plugins/ipoib.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/plugins/ipoib.py
@@ -1,0 +1,15 @@
+from pyroute2.netlink import nla
+from pyroute2.netlink import nlmsg_atoms
+
+
+class ipoib(nla):
+    prefix = 'IFLA_IPOIB_'
+
+    nla_map = (('IFLA_IPOIB_UNSPEC', 'none'),
+               ('IFLA_IPOIB_PKEY', 'uint16'),
+               ('IFLA_IPOIB_MODE', 'mode'),
+               ('IFLA_IPOIB_UMCAST', 'uint16'))
+
+    class mode(nlmsg_atoms.uint16):
+        value_map = {0: 'datagram',
+                     1: 'connected'}


### PR DESCRIPTION
- Add ipoib nla to allow creation/query of ipoib interfaces
  with the defined attributes.

- Document ipoib usage in iproute.linux.RTNL_API.link() docstring.