### PR TITLE
ss2: curing nonetype pid

### DIFF
--- a/cli/ss2
+++ b/cli/ss2
@@ -111,6 +111,11 @@ class UserCtxtMap(collections.Mapping):
                             _recurs_path=_recurs_path)
 
     def _enter_item(self, usr, flow, ctxt):
+        if not flow.pid:
+            # corner case of eg anonnymous AddressFamily.AF_UNIX
+            # sockets
+            return
+
         sk_inode = int(self._parse_inode(flow))
         sk_fd = flow.fd
 


### PR DESCRIPTION
E.g. glitching for:

sconn(fd=-1, family=<AddressFamily.AF_UNIX: 1>, type=1, laddr='/run/systemd/private', raddr='', status='NONE', pid=None)

With:

[...]
"/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/pyroute2-0.5.6-py3.7.egg/EGG-INFO/scripts/ss2",
line 114, in _enter_item sk_inode = int(self._parse_inode(flow))
File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/pyroute2-0.5.6-py3.7.egg/EGG-INFO/scripts/ss2",
line 64, in _parse_inode sk_path = self._proc_sk_fd_cast % (sconn.pid, sconn.fd) TypeError: %d %format: %a %number %is %required,
%not NoneType