### PR TITLE
NetNS: fix the FD leakage

### DIFF
--- a/pyroute2/netns/nslink.py
+++ b/pyroute2/netns/nslink.py
@@ -145,6 +145,8 @@ class NetNS(RTNL_API, RemoteSocket):
             # child process
             trnsp_in.close()
             trnsp_out.close()
+            trnsp_in.file_obj.close()
+            trnsp_out.file_obj.close()
             try:
                 setns(self.netns, self.flags)
             except OSError as e:


### PR DESCRIPTION
With the change in the behavior of the Transport object, we now need to
close the file_obj associated with the Transport object manually.

Closes #623