### PR TITLE
Set infiniband port and node GUID

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
@@ -517,9 +517,41 @@ class ifinfbase(object):
                        ('IFLA_VF_RSS_QUERY_EN', 'vf_rss_query_en'),
                        ('IFLA_VF_STATS', 'vf_stats'),
                        ('IFLA_VF_TRUST', 'vf_trust'),
-                       ('IFLA_VF_IB_NODE_GUID', 'hex'),
-                       ('IFLA_VF_IB_PORT_GUID', 'hex'),
+                       ('IFLA_VF_IB_NODE_GUID', 'vf_ib_node_guid'),
+                       ('IFLA_VF_IB_PORT_GUID', 'vf_ib_port_guid'),
                        ('IFLA_VF_VLAN_LIST', 'vf_vlist'))
+
+            class vf_ib_node_guid(nla):
+                fields = (('vf', 'I'),
+                          ('ib_node_guid', '32B'))
+
+                def decode(self):
+                    nla.decode(self)
+                    self['ib_node_guid'] = ':'.join([
+                        '%02x' % x for x in self['ib_node_guid'][4:12][::-1]])
+
+                def encode(self):
+                    encoded_guid = self['ib_node_guid'].split(':')[::-1]
+                    self['ib_node_guid'] = (
+                        [0] * 4 + [int(x, 16) for x in encoded_guid] +
+                        [0] * 20)
+                    nla.encode(self)
+
+            class vf_ib_port_guid(nla):
+                fields = (('vf', 'I'),
+                          ('ib_port_guid', '32B'))
+
+                def decode(self):
+                    nla.decode(self)
+                    self['ib_port_guid'] = ':'.join([
+                        '%02x' % x for x in self['ib_port_guid'][4:12][::-1]])
+
+                def encode(self):
+                    encoded_guid = self['ib_port_guid'].split(':')[::-1]
+                    self['ib_port_guid'] = (
+                        [0] * 4 + [int(x, 16) for x in encoded_guid] +
+                        [0] * 20)
+                    nla.encode(self)
 
             class vf_mac(nla):
                 fields = (('vf', 'I'),


### PR DESCRIPTION
This patch adds the abbility to configure infiniband port GUID
and node GUID by implementing classes `ib_port_guid` and `ib_node_guid`
in class IFLA_VF_INFO for serializing and deserializing GUID.