### PR TITLE
ipdb: don't print debug message when RouteKey is changed

### DIFF
--- a/pyroute2/ipdb/routes.py
+++ b/pyroute2/ipdb/routes.py
@@ -1138,6 +1138,13 @@ class RoutingTableSet(object):
         # RTM_DELROUTE
         if msg['event'] == 'RTM_DELROUTE':
             try:
+                # If a route is updated such that the RouteKey changes,
+                # then a new kernel route is added, the old kernel route
+                # is deleted, and there is no record to delete when the
+                # RTM_DELROUTE message for the old kernel route is
+                # received.
+                if msg not in self.tables[table]:
+                    return
                 # locate the record
                 record = self.tables[table][msg]
                 # delete the record


### PR DESCRIPTION
If a route is updated in a way that causes the RouteKey to change, then a harmless but annoying debug message is printed.  For example:
```
# ip route add table 1 1.2.3.4/32 dev eth0 metric 10
# python
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> from pyroute2 import IPDB
>>> ipdb = IPDB()
>>> route = ipdb.routes.tables[1][0]
>>> route['priority'] = 20
>>> route.commit()
DEBUG:pyroute2.ipdb.routes:delroute failed for RouteKey(dst='1.2.3.4/32', table=1, family=2, priority=10, tos=0)
```
This commit suppresses the debug message.