### PR TITLE
wiset: Add support for "mark" ipset type.

### DIFF
--- a/pyroute2/wiset.py
+++ b/pyroute2/wiset.py
@@ -235,6 +235,8 @@ class WiSet(object):
                     key += entry.get_attr("IPSET_ATTR_IFACE")
                 elif parse_type == "set":
                     key += entry.get_attr("IPSET_ATTR_NAME")
+                elif parse_type == "mark":
+                    key += str(hex(entry.get_attr("IPSET_ATTR_MARK")))
                 key += ","
 
             key = key.strip(",")


### PR DESCRIPTION
When creating an ipset of type 'hash:ip,mark' or any other type contaning marks, wiset silently drops the mark from entry keys.

This PR adds support for parsing the mark and adding it to the entry key.