### PR TITLE
Add support route('append', ...) operation

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -1761,11 +1761,12 @@ class RTNL_API(object):
                             'srh': {'segs': '2000::5,2000::6',
                                     'hmac':0xf}})
 
-        **change**, **replace**
+        **change**, **replace**, **append**
 
-        Commands `change` and `replace` have the same meanings, as
-        in ip-route(8): `change` modifies only existing route, while
+        Commands `change`, `replace` and `append` have the same meanings
+        as in ip-route(8): `change` modifies only existing route, while
         `replace` creates a new one, if there is no such route yet.
+        `append` allows to create an IPv6 multipath route.
 
         **del**
 
@@ -1787,10 +1788,11 @@ class RTNL_API(object):
         flags_make = flags_base | NLM_F_CREATE | NLM_F_EXCL
         flags_change = flags_base | NLM_F_REPLACE
         flags_replace = flags_change | NLM_F_CREATE
+        flags_append = flags_base | NLM_F_CREATE | NLM_F_APPEND
         # 8<----------------------------------------------------
         # transform kwarg
 
-        if command in ('add', 'set', 'replace', 'change'):
+        if command in ('add', 'set', 'replace', 'change', 'append'):
             kwarg['proto'] = kwarg.get('proto', 'static') or 'static'
             kwarg['type'] = kwarg.get('type', 'unicast') or 'unicast'
         kwarg = IPRouteRequest(kwarg)
@@ -1804,6 +1806,7 @@ class RTNL_API(object):
                     'set': (RTM_NEWROUTE, flags_replace),
                     'replace': (RTM_NEWROUTE, flags_replace),
                     'change': (RTM_NEWROUTE, flags_change),
+                    'append': (RTM_NEWROUTE, flags_append),
                     'del': (RTM_DELROUTE, flags_make),
                     'remove': (RTM_DELROUTE, flags_make),
                     'delete': (RTM_DELROUTE, flags_make),


### PR DESCRIPTION
iproute2 supports `ip route append ...` command, that allows, possibly
among other things, to set up IPv6 multipath 'device only' routes that
cannot be confitured via the kernel "multipath" interface. Relevant code
in the iproute2 source in ip/iproute.c:2295 looks like this:

        if (matches(*argv, "append") == 0)
                return iproute_modify(RTM_NEWROUTE, NLM_F_CREATE|NLM_F_APPEND,
                                      argc-1, argv+1);

This commit aims to replicate this functionality in pyroute2.

Signed-off-by: Eugene Crosser <evgenii.cherkashin@cloud.ionos.com>