### PR TITLE
Create namespace recursively bind-mounting

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -222,7 +222,8 @@ def _create(netns, libc=None):
     while libc.mount(b'', netnsdir, b'none', MS_SHARED | MS_REC, None) != 0:
         if done:
             raise OSError(ctypes.get_errno(), 'share rundir failed', netns)
-        if libc.mount(netnsdir, netnsdir, b'none', MS_BIND, None) != 0:
+        if libc.mount(netnsdir, netnsdir, b'none', MS_BIND | MS_REC,
+                      None) != 0:
             raise OSError(ctypes.get_errno(), 'mount rundir failed', netns)
         done = True
 


### PR DESCRIPTION
When ip netns {add|delete} is first run, it bind-mounts /var/run/netns
on top of itself, then marks it as shared. However, if there are already
bind-mounts in the directory from other tools, these would not be
propagated. Fix this by recursively bind-mounting.

Related Patch: https://patchwork.ozlabs.org/patch/796300/

Issue: 640