### PR TITLE
WireGuard: multiple fixes

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/tcmsg/__init__.py
@@ -9,6 +9,7 @@ from pyroute2.netlink.rtnl.tcmsg import cls_matchall
 from pyroute2.netlink.rtnl.tcmsg import cls_basic
 from pyroute2.netlink.rtnl.tcmsg import cls_flow
 from pyroute2.netlink.rtnl.tcmsg import sched_bpf
+from pyroute2.netlink.rtnl.tcmsg import sched_cake
 from pyroute2.netlink.rtnl.tcmsg import sched_choke
 from pyroute2.netlink.rtnl.tcmsg import sched_clsact
 from pyroute2.netlink.rtnl.tcmsg import sched_codel
@@ -43,7 +44,8 @@ plugins = {'plug': sched_plug,
            'pfifo_fast': sched_pfifo_fast,
            'choke': sched_choke,
            'drr': sched_drr,
-           'prio': sched_pfifo_fast}
+           'prio': sched_pfifo_fast,
+           'cake': sched_cake}
 
 
 class tcmsg(nlmsg):

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -43,6 +43,32 @@ def fix_msg(msg, kwarg):
         msg['parent'] = TC_H_ROOT
 
 
+def convert_bandwidth(value):
+    types = [('kbit', 1000),
+             ('mbit', 1000000),
+             ('gbit', 1000000000)
+            ]
+
+    if 'unlimited' == value:
+        return 0
+
+    try:
+        # Value is passed as an int
+        x = int(value)
+        return x >> 3
+    except ValueError:
+        value = value.lower()
+        for entry in types:
+            t, mul = entry
+            if len(value.split(t)) == 2:
+                x = int(value.split(t)[0]) * mul
+                return x >> 3;
+
+    raise ValueError('Invalid bandwidth value. Specify either an integer, \
+                      "unlimited" or a value with "bit", "kbit", "mbit" or \
+                      "gbit" appended')
+
+
 def get_parameters(kwarg):
     ret = {'attrs': []}
     attrs_map = (('bandwidth', 'TCA_CAKE_BASE_RATE64'),
@@ -54,10 +80,7 @@ def get_parameters(kwarg):
         r = kwarg.get(k, None)
         if r is not None:
             if k == 'bandwidth':
-                if r == 'unlimited':
-                    r = 0
-                else:
-                    r >>= 3
+                r = convert_bandwidth(r)
             ret['attrs'].append([v, r])
 
     return ret

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -1,3 +1,27 @@
+'''
+cake
+++++
+
+Usage:
+
+    # Imports
+    from pyroute2 import IPRoute
+
+
+    # Add cake with 2048kbit of bandwidth capacity
+    with IPRoute() as ipr:
+        # Get interface index
+        index = ipr.link_lookup(ifname='lo')
+        ipr.tc('add', kind='cake', index=index, bandwidth='2048kbit')
+
+    # Same with 15mbit of bandwidth capacity
+    with IPRoute() as ipr:
+        # Get interface index
+        index = ipr.link_lookup(ifname='lo')
+        ipr.tc('add', kind='cake', index=index, bandwidth='15mbit')
+'''
+
+
 from socket import htons
 from pyroute2 import protocols
 from pyroute2.netlink import nla

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -73,8 +73,6 @@ NOTES:
 '''
 
 
-from socket import htons
-from pyroute2 import protocols
 from pyroute2.netlink import nla
 from pyroute2.netlink.rtnl import TC_H_ROOT
 
@@ -113,7 +111,7 @@ def convert_bandwidth(value):
     types = [('kbit', 1000),
              ('mbit', 1000000),
              ('gbit', 1000000000)
-            ]
+             ]
 
     if 'unlimited' == value:
         return 0
@@ -144,7 +142,7 @@ def convert_rtt(value):
              ('oceanic', 300000),
              ('satellite', 1000000),
              ('interplanetary', 3600000000),
-            ]
+             ]
 
     try:
         # Value is passed as an int

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -1,7 +1,7 @@
 from pyroute2.netlink import nla
 
 
-# Defines from sch_ckae.c
+# Defines from sch_cake.c
 CAKE_FLAG_OVERHEAD = 0
 CAKE_FLAG_AUTORATE_INGRESS = 1
 CAKE_FLAG_INGRESS = 2
@@ -10,14 +10,39 @@ CAKE_FLAG_SPLIT_GSO = 4
 CAKE_FLAG_STORE_MARK = 5
 CAKE_FLAG_SCE = 6
 
+# Defines from pkt_sched.h
+CAKE_FLOW_NONE = 0
+CAKE_FLOW_SRC_IP = 1
+CAKE_FLOW_DST_IP = 2
+CAKE_FLOW_HOSTS = 3
+CAKE_FLOW_FLOWS = 4
+CAKE_FLOW_DUAL_SRC = 5
+CAKE_FLOW_DUAL_DST = 6
+CAKE_FLOW_TRIPLE = 7
+
+CAKE_DIFFSERV_DIFFSERV3 = 0
+CAKE_DIFFSERV_DIFFSERV4 = 1
+CAKE_DIFFSERV_DIFFSERV8 = 2
+CAKE_DIFFSERV_BESTEFFORT = 3
+CAKE_DIFFSERV_PRECEDENCE = 4
+
+CAKE_ACK_NONE = 0
+CAKE_ACK_FILTER = 1
+CAKE_ACK_AGGRESSIVE = 2
+
+CAKE_ATM_NONE = 0
+CAKE_ATM_ATM = 1
+CAKE_ATM_PTM = 2
+
 
 class options(nla):
-    nla_map = (('TCA_CAKE_BASE_UNSPEC', 'none'),
+    nla_map = (('TCA_CAKE_UNSPEC', 'none'),
+               ('TCA_CAKE_PAD', 'uint64'),
                ('TCA_CAKE_BASE_RATE64', 'uint64'),
                ('TCA_CAKE_DIFFSERV_MODE', 'uint32'),
                ('TCA_CAKE_ATM', 'uint32'),
                ('TCA_CAKE_FLOW_MODE', 'uint32'),
-               ('TCA_CAKE_OVERHEAD', 'uint32'),
+               ('TCA_CAKE_OVERHEAD', 'int32'),
                ('TCA_CAKE_RTT', 'uint32'),
                ('TCA_CAKE_TARGET', 'uint32'),
                ('TCA_CAKE_AUTORATE', 'uint32'),

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -1,0 +1,34 @@
+from pyroute2.netlink import nla
+
+
+# Defines from sch_ckae.c
+CAKE_FLAG_OVERHEAD = 0
+CAKE_FLAG_AUTORATE_INGRESS = 1
+CAKE_FLAG_INGRESS = 2
+CAKE_FLAG_WASH = 3
+CAKE_FLAG_SPLIT_GSO = 4
+CAKE_FLAG_STORE_MARK = 5
+CAKE_FLAG_SCE = 6
+
+
+class options(nla):
+    nla_map = (('TCA_CAKE_BASE_UNSPEC', 'none'),
+               ('TCA_CAKE_BASE_RATE64', 'uint64'),
+               ('TCA_CAKE_DIFFSERV_MODE', 'uint32'),
+               ('TCA_CAKE_ATM', 'uint32'),
+               ('TCA_CAKE_FLOW_MODE', 'uint32'),
+               ('TCA_CAKE_OVERHEAD', 'uint32'),
+               ('TCA_CAKE_RTT', 'uint32'),
+               ('TCA_CAKE_TARGET', 'uint32'),
+               ('TCA_CAKE_AUTORATE', 'uint32'),
+               ('TCA_CAKE_MEMORY', 'uint32'),
+               ('TCA_CAKE_NAT', 'uint32'),
+               ('TCA_CAKE_RAW', 'uint32'),
+               ('TCA_CAKE_WASH', 'uint32'),
+               ('TCA_CAKE_MPU', 'uint32'),
+               ('TCA_CAKE_INGRESS', 'uint32'),
+               ('TCA_CAKE_ACK_FILTER', 'uint32'),
+               ('TCA_CAKE_FWMARK', 'uint32'),
+               ('TCA_CAKE_FWMARK_STORE', 'uint32'),
+               ('TCA_CAKE_SCE', 'uint32'),
+               )

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -35,15 +35,6 @@ from pyroute2.netlink import nla
 from pyroute2.netlink.rtnl import TC_H_ROOT
 
 
-# Defines from sch_cake.c
-CAKE_FLAG_OVERHEAD = 0
-CAKE_FLAG_AUTORATE_INGRESS = 1
-CAKE_FLAG_INGRESS = 2
-CAKE_FLAG_WASH = 3
-CAKE_FLAG_SPLIT_GSO = 4
-CAKE_FLAG_STORE_MARK = 5
-CAKE_FLAG_SCE = 6
-
 # Defines from pkt_sched.h
 CAKE_FLOW_NONE = 0
 CAKE_FLOW_SRC_IP = 1

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -222,6 +222,16 @@ def convert_ackfilter(value):
             return CAKE_ACK_AGGRESSIVE
 
 
+def check_range(name, value, start, end):
+    if not type(value) == int:
+        raise ValueError('{} value must be an integer'.format(name))
+
+    x = int(value)
+    if not start <= x <= end:
+        raise ValueError('{0} value must be between {1} and {2} \
+                          inclusive.'.format(name, start, end))
+
+
 def get_parameters(kwarg):
     ret = {'attrs': []}
     attrs_map = (('ack_filter', 'TCA_CAKE_ACK_FILTER'),
@@ -258,6 +268,10 @@ def get_parameters(kwarg):
                 r = convert_diffserv(r)
             elif k == 'ack_filter':
                 r = convert_ackfilter(r)
+            elif k == 'mpu':
+                check_range(k, r, 0, 256)
+            elif k == 'overhead':
+                check_range(k, r, -64, 256)
             ret['attrs'].append([v, r])
 
     return ret

--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -20,12 +20,56 @@ Usage:
         index = ipr.link_lookup(ifname='lo')
         ipr.tc('add', kind='cake', index=index, bandwidth='15mbit')
 
-    # If you don't known the bandwidth capacity, use autorate
+    # If you don't know the bandwidth capacity, use autorate
     with IPRoute() as ipr:
         # Get interface index
         index = ipr.link_lookup(ifname='lo')
         ipr.tc('add', kind='cake', index=index, bandwidth='unlimited',
                autorate=True)
+
+    # If you want to tune ATM properties use:
+    # atm=False # For no ATM tuning
+    # atm=True # For ADSL tuning
+    # atm='ptm' # For VDSL2 tuning
+    with IPRoute() as ipr:
+        # Get interface index
+        index = ipr.link_lookup(ifname='lo')
+        ipr.tc('add', kind='cake', index=index, bandwidth='unlimited',
+               autorate=True)
+
+    # Complex example which has no-sense
+    with IPRoute() as ipr:
+        # Get interface index
+        index = ipr.link_lookup(ifname='lo')
+        ipr.tc('add', kind='cake', index=index, bandwidth='unlimited',
+               autorate=True, nat=True, rtt='interplanetary', target=10000,
+               flow_mode='dsthost', diffserv_mode='precedence', fwmark=0x1337)
+
+NOTES:
+    Here is the list of all supported options with their values:
+    - ack_filter: False, True or 'aggressive' (False by default)
+    - atm_mode: False, True or 'ptm' (False by default)
+    - autorate: False or True (False by default)
+    - bandwidth: any integer, 'N[kbit|mbit|gbit]' or 'unlimited'
+    - diffserv_mode: 'diffserv3', 'diffserv4', 'diffserv8',
+        'besteffort', 'precedence' ('diffserv3' by default)
+    - ingress: False or True (False by default)
+    - overhead: any integer between -64 and 256 inclusive (0 by default)
+    - flow_mode: 'flowblind', 'srchost', 'dsthost', 'hosts', 'flows',
+        'dual-srchost', 'dual-dsthost', 'triple-isolate'
+        ('triple-isolate' by default)
+    - fwmark: any integer (0 by default)
+    - memlimit: any integer (by default, calculated based on the bandwidth
+        and RTT settings)
+    - mpu: any integer between 0 and 256 inclusive (0 by default)
+    - nat: False or True (False by default)
+    - raw: False or True (True by default)
+    - rtt: any integer or 'datacentre', 'lan', 'metro', 'regional',
+        'internet', 'oceanic', 'satellite', 'interplanetary'
+        ('internet' by default)
+    - split_gso: False or True (True by default)
+    - target: any integer (5000 by default)
+    - wash: False or True (False by default)
 '''
 
 
@@ -185,6 +229,8 @@ def get_parameters(kwarg):
                  ('autorate', 'TCA_CAKE_AUTORATE'),
                  ('bandwidth', 'TCA_CAKE_BASE_RATE64'),
                  ('diffserv_mode', 'TCA_CAKE_DIFFSERV_MODE'),
+                 ('ingress', 'TCA_CAKE_INGRESS'),
+                 ('overhead', 'TCA_CAKE_OVERHEAD'),
                  ('flow_mode', 'TCA_CAKE_FLOW_MODE'),
                  ('fwmark', 'TCA_CAKE_FWMARK'),
                  ('memlimit', 'TCA_CAKE_MEMORY'),
@@ -192,8 +238,9 @@ def get_parameters(kwarg):
                  ('nat', 'TCA_CAKE_NAT'),
                  ('raw', 'TCA_CAKE_RAW'),
                  ('rtt', 'TCA_CAKE_RTT'),
+                 ('split_gso', 'TCA_CAKE_SPLIT_GSO'),
+                 ('target', 'TCA_CAKE_TARGET'),
                  ('wash', 'TCA_CAKE_WASH'),
-                 ('overhead', 'TCA_CAKE_OVERHEAD'), #
                  )
 
     for k, v in attrs_map:
@@ -234,9 +281,8 @@ class options(nla):
                ('TCA_CAKE_MPU', 'uint32'),
                ('TCA_CAKE_INGRESS', 'uint32'),
                ('TCA_CAKE_ACK_FILTER', 'uint32'),
+               ('TCA_CAKE_SPLIT_GSO', 'uint32'),
                ('TCA_CAKE_FWMARK', 'uint32'),
-               ('TCA_CAKE_FWMARK_STORE', 'uint32'),
-               ('TCA_CAKE_SCE', 'uint32'),
                )
 
     def encode(self):


### PR DESCRIPTION
Since the update of the WireGuard code now using .NLA_EXACT_LEN attributes (see https://github.com/WireGuard/WireGuard/blob/19b2fb70620d5d664549b1e9dd5f123ab1a1baf5/src/netlink.c#L32), header types of the following classes are not correctly set when encoding NLAs:
- wgpeer_a_allowedips
- wgpeer_allowedip
- wgdevice_a_peers
- wgdevice_peer

So I forced them, taken from dumps of netlink messages using the 'wg' command.
I don't know if it's really related with .NLA_EXACT_LEN attributes but I did not understand how these values are built.

It also includes a fix for Python2 and empty IPv6 endpoint address.