### PR TITLE
Enable action parameter for basic, flow and fw filters

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/cls_fw.py
+++ b/pyroute2/netlink/rtnl/tcmsg/cls_fw.py
@@ -4,6 +4,9 @@ from pyroute2.netlink import nla
 from pyroute2.netlink.rtnl.tcmsg.act_police import nla_plus_police
 from pyroute2.netlink.rtnl.tcmsg.act_police import get_parameters \
     as ap_parameters
+from pyroute2.netlink.rtnl.tcmsg.common import TCA_ACT_MAX_PRIO
+from pyroute2.netlink.rtnl.tcmsg.common_act import get_tca_action
+from pyroute2.netlink.rtnl.tcmsg.common_act import nla_plus_tca_act_opt
 
 
 def fix_msg(msg, kwarg):
@@ -15,7 +18,6 @@ def get_parameters(kwarg):
     ret = {'attrs': []}
     attrs_map = (
         ('classid', 'TCA_FW_CLASSID'),
-        ('act', 'TCA_FW_ACT'),
         # ('police', 'TCA_FW_POLICE'),
         # Handled in ap_parameters
         ('indev', 'TCA_FW_INDEV'),
@@ -24,6 +26,9 @@ def get_parameters(kwarg):
 
     if kwarg.get('rate'):
         ret['attrs'].append(['TCA_FW_POLICE', ap_parameters(kwarg)])
+
+    if kwarg.get('action'):
+        ret['attrs'].append(['TCA_FW_ACT', get_tca_action(kwarg)])
 
     for k, v in attrs_map:
         r = kwarg.get(k, None)
@@ -38,5 +43,16 @@ class options(nla, nla_plus_police):
                ('TCA_FW_CLASSID', 'uint32'),
                ('TCA_FW_POLICE', 'police'),  # TODO string?
                ('TCA_FW_INDEV', 'hex'),  # TODO string
-               ('TCA_FW_ACT', 'hex'),  # TODO
+               ('TCA_FW_ACT', 'tca_act_prio'),
                ('TCA_FW_MASK', 'uint32'))
+
+    class tca_act_prio(nla):
+        nla_map = tuple([('TCA_ACT_PRIO_%i' % x, 'tca_act') for x
+                         in range(TCA_ACT_MAX_PRIO)])
+
+        class tca_act(nla,
+                      nla_plus_tca_act_opt):
+            nla_map = (('TCA_ACT_UNSPEC', 'none'),
+                       ('TCA_ACT_KIND', 'asciiz'),
+                       ('TCA_ACT_OPTIONS', 'get_act_options'),
+                       ('TCA_ACT_INDEX', 'hex'))


### PR DESCRIPTION
'action' support was not enable on these three filters. This patch enables it.