### PR TITLE
Test: Check wireguard sets endpoint address properly

### DIFF
--- a/tests/general/test_wireguard.py
+++ b/tests/general/test_wireguard.py
@@ -53,3 +53,6 @@ class TestBasic(object):
 
         assert grep('wg show %s' % self.ifnames[0],
                     pattern='peer: %s' % peer['public_key'])
+        assert grep('wg show %s' % self.ifnames[0],
+                    pattern='endpoint: %s:%s' %
+                    (peer['endpoint_addr'], peer['endpoint_port']))


### PR DESCRIPTION
This extends the simple wireguard test to check that, as well as the peer existing, the endpoint address has been set.