### PR TITLE
wiset: do not raise exception on recent kernels

### DIFF
--- a/pyroute2/wiset.py
+++ b/pyroute2/wiset.py
@@ -443,7 +443,13 @@ def load_ipset(name, content=False, sock=None, inherit_sock=False):
     :type inherit_sock: bool
     """
     res = None
-    for msg in sock.list(name=name):
+    try:
+        messages = sock.list(name=name)
+    except IPSetError as e:
+        if e.code == errno.ENOENT:
+            return res
+        raise
+    for msg in messages:
         if res is None:
             res = WiSet.from_netlink(msg, content=content)
             if inherit_sock:

--- a/tests/general/test_wiset.py
+++ b/tests/general/test_wiset.py
@@ -354,6 +354,10 @@ class WiSet_test(object):
         assert content["192.168.0.0/24,eth"].wildcard is True
         assert content["192.168.1.0/24,wlan0"].wildcard is False
 
+    @staticmethod
+    def test_invalid_load_ipset():
+        assert load_ipset("ipsetdoesnotexists") is None
+
     def test_ipset_context(self):
         before_count = COUNT["count"]
         func = [self.test_create_one_ipset, self.test_create_ipset_twice,


### PR DESCRIPTION
On "old" kernels, like version 4.19, the kernel does not return any
message for an invalid ipset name:

In [2]: load_ipset("doesnotexists")
In [3]:

However, on recent kernel, we now receive an error. It's probably a good
thing, but it breaks our code compatibility here. So we know catch the
exception to keep consistent behaviour between kernel versions