### PR TITLE
Add support for 'replace' command in addr method

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -1348,7 +1348,7 @@ class RTNL_API(object):
         '''
         Address operations
 
-        * command -- add, delete
+        * command -- add, delete, replace, dump
         * index -- device index
         * address -- IPv4 or IPv6 address
         * mask -- address mask
@@ -1396,11 +1396,14 @@ class RTNL_API(object):
             return
 
         flags_dump = NLM_F_REQUEST | NLM_F_DUMP
-        flags_create = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL
+        flags_base = NLM_F_REQUEST | NLM_F_ACK
+        flags_create = flags_base | NLM_F_CREATE | NLM_F_EXCL
+        flags_replace = flags_base | NLM_F_REPLACE | NLM_F_CREATE
         commands = {'add': (RTM_NEWADDR, flags_create),
                     'del': (RTM_DELADDR, flags_create),
                     'remove': (RTM_DELADDR, flags_create),
                     'delete': (RTM_DELADDR, flags_create),
+                    'replace': (RTM_NEWADDR, flags_replace),
                     'dump': (RTM_GETADDR, flags_dump)}
         (command, flags) = commands.get(command, command)
 

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -212,6 +212,13 @@ class TestIPRoute(object):
         self.ip.addr('add', self.ifaces[0], address=ifaddr, mask=24)
         assert '{0}/24'.format(ifaddr) in get_ip_addr()
 
+    def test_addr_replace(self):
+        require_user('root')
+        ifaddr = self.ifaddr()
+        self.ip.addr('replace', self.ifaces[0], address=ifaddr, mask=24)
+        assert '{0}/24'.format(ifaddr) in get_ip_addr()
+        self.ip.addr('replace', self.ifaces[0], address=ifaddr, mask=24)
+
     def test_vlan_filter_dump(self):
         require_user('root')
         (an, ax) = self.create('bridge')


### PR DESCRIPTION
addr method only accepts 'add', 'delete' and 'dump' commands.
This commit adds 'replace' and a test.