### PR TITLE
docs: Fix README.rst path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ module = __import__(config.get('setup', 'setuplib'),
                     ['setup'], 0)
 setup = getattr(module, 'setup')
 
-readme = open("README.md", "r")
+readme = open("README.rst", "r")
 
 
 setup(name='pyroute2',


### PR DESCRIPTION
The change in e5f610de7e92782f6d66fd3f53baf1df6bdacc88 introduced a
README.rst in place of the README.md but this was not reflected in
setup.py.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>