### PR TITLE
linux: add support of ip neigh get

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -910,6 +910,15 @@ class RTNL_API(object):
         Dump all the records in the NDB::
 
             ip.neigh('dump')
+
+        **get**
+
+        Get specific record (dst and ifindex are mandatory). Available
+        only on recent kernel::
+
+            ip.neigh('get',
+                     dst='172.16.45.1',
+                     ifindex=idx)
         '''
         if (command == 'dump') and ('match' not in kwarg):
             match = kwarg
@@ -931,6 +940,7 @@ class RTNL_API(object):
                     'remove': (RTM_DELNEIGH, flags_make),
                     'delete': (RTM_DELNEIGH, flags_make),
                     'dump': (RTM_GETNEIGH, flags_dump),
+                    'get': (RTM_GETNEIGH, flags_base),
                     'append': (RTM_NEWNEIGH, flags_append)}
 
         (command, flags) = commands.get(command, command)

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -604,6 +604,18 @@ class TestIPRoute(object):
         assert len(self.ip.get_neighbours(match=lambda x: x['ifindex'] ==
                                           self.ifaces[0])) == 2
 
+    def test_neigh_get(self):
+        require_user('root')
+        ifaddr1 = self.ifaddr(1)
+        self.ip.neigh('add',
+                      dst=ifaddr1,
+                      lladdr='00:11:22:33:44:55',
+                      ifindex=self.ifaces[0])
+        res = self.ip.neigh('get',
+                            dst=ifaddr1,
+                            ifindex=self.ifaces[0])
+        assert res[0].get_attr("NDA_DST") == ifaddr1
+
     def test_mass_ipv6(self):
         #
         # Achtung! This test is time consuming.


### PR DESCRIPTION
This feature has been added in kernel recently (end of 2018), and is now
in iproute2 as well