### PR TITLE
iproute: fix link_lookup when index/ifname is not set

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -521,7 +521,7 @@ class RTNL_API(object):
         Please note, that link_lookup() returns list, not one
         value.
         '''
-        if list(kwarg) <= ['index', 'ifname']:
+        if set(kwarg) & {'index', 'ifname'}:
             # shortcut for index and ifname
             try:
                 return [self.link('get', **kwarg)[0]['index']]

--- a/tests/general/test_ipr.py
+++ b/tests/general/test_ipr.py
@@ -1350,3 +1350,9 @@ class TestIPRoute(object):
         assert len(routes)
         assert all([isinstance(x, dict) for x in routes])
         assert all([x['event'] == 'RTM_NEWROUTE' for x in routes])
+
+    def test_link_lookup(self):
+        ifindex = self._create('dummy')[1]
+        interface = self.ip.get_links(ifindex)[0]
+        res = self.ip.link_lookup(address=interface.get_attr('IFLA_ADDRESS'))
+        assert ifindex == res[0]


### PR DESCRIPTION
Use set intersection to check if index nor ifname is in kwargs. And add
a trivial test for this

Bug-Url: https://github.com/svinota/pyroute2/issues/724
Related-To: https://github.com/svinota/pyroute2/issues/712