### PR TITLE
linux/neigh: do not run _match when match is an empty dict

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -963,7 +963,7 @@ class RTNL_API(object):
         ret = self.nlm_request(msg,
                                msg_type=command,
                                msg_flags=flags)
-        if match is not None:
+        if match:
             ret = self._match(match, ret)
 
         if not (command == RTM_GETNEIGH and self.nlm_generator):


### PR DESCRIPTION
Hello,

It's not a huge improvement, but we just catched it we doing some performance profiling