### PR TITLE
nftables: Allow negative hook priority and fix typo

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1696,6 +1696,34 @@ class nlmsg_atoms(nlmsg_base):
 
         fields = [('value', '>Q')]
 
+    class sbe8(nla_base):
+
+        __slots__ = ()
+        sql_type = 'INTEGER'
+
+        fields = [('value', '>b')]
+
+    class sbe16(nla_base):
+
+        __slots__ = ()
+        sql_type = 'INTEGER'
+
+        fields = [('value', '>h')]
+
+    class sbe32(nla_base):
+
+        __slots__ = ()
+        sql_type = 'BIGINT'
+
+        fields = [('value', '>i')]
+
+    class sbe64(nla_base):
+
+        __slots__ = ()
+        sql_type = 'BIGINT'
+
+        fields = [('value', '>q')]
+
     class ipXaddr(nla_base):
 
         __slots__ = ()

--- a/pyroute2/netlink/nfnetlink/nftsocket.py
+++ b/pyroute2/netlink/nfnetlink/nftsocket.py
@@ -106,7 +106,7 @@ class nft_regs(nla):
                0x03: 'NFT_REG_3',
                0x04: 'NFT_REG_4',
                0x08: 'NFT_REG32_00',
-               0x09: 'MFT_REG32_01',
+               0x09: 'NFT_REG32_01',
                0x0a: 'NFT_REG32_02',
                0x0b: 'NFT_REG32_03',
                0x0c: 'NFT_REG32_04',

--- a/pyroute2/netlink/nfnetlink/nftsocket.py
+++ b/pyroute2/netlink/nfnetlink/nftsocket.py
@@ -58,7 +58,7 @@ class nft_chain_msg(nfgen_msg):
     class hook(nla):
         nla_map = (('NFTA_HOOK_UNSPEC', 'none'),
                    ('NFTA_HOOK_HOOKNUM', 'be32'),
-                   ('NFTA_HOOK_PRIORITY', 'be32'),
+                   ('NFTA_HOOK_PRIORITY', 'sbe32'),
                    ('NFTA_HOOK_DEV', 'asciiz'))
 
 


### PR DESCRIPTION
Base chain priority can be negative (see https://wiki.nftables.org/wiki-nftables/index.php/Configuring_chains). However, since an unsigned value is used, an exception will be thrown when the struct module attempts to pack a negative value that is passed to `NFTables.rule` as the priority parameter. Thus, ff0f00cb309464fa2b406a70ec05abd42f27c0a8 adds signed big endian values.

0c78cd03991786465fe0b01b32a325acea9bf613 fixes a typo.