### PR TITLE
Add nftables docs + simple example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Usage
     ipdb_toc
     wiset
     ipset
+    nftables
     netns
     wireguard
 

--- a/docs/nftables.rst
+++ b/docs/nftables.rst
@@ -1,0 +1,16 @@
+.. _nftables:
+
+NFTables module
+============
+
+.. automodule:: pyroute2.nftables
+    :members:
+
+.. automodule:: pyroute2.nftables.expr
+    :members:
+
+.. automodule:: pyroute2.nftables.main
+    :members:
+
+.. automodule:: pyroute2.nftables.rule
+    :members:

--- a/examples/nftables.py
+++ b/examples/nftables.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from pyroute2.nftables.main import NFTables
+
+
+# nfgen_family 0 == inet
+def show_nftables(family: int = 0) -> None:
+        nft = NFTables(nfgen_family=family)
+        tables = nft.get_tables()
+        chains = nft.get_chains()
+        rules = nft.get_rules()
+
+        print("Tables:")
+        print(tables)
+        print("\nChains:")
+        print(chains)
+        print("\nRules:")
+        for rule in rules:
+            print(rule, type(rule))
+        print(f"Interfaces:\n{avail_interfaces}")
+
+
+show_nftables(0)

--- a/examples/nftables.py
+++ b/examples/nftables.py
@@ -17,7 +17,6 @@ def show_nftables(family: int = 0) -> None:
         print("\nRules:")
         for rule in rules:
             print(rule, type(rule))
-        print(f"Interfaces:\n{avail_interfaces}")
 
 
 show_nftables(0)


### PR DESCRIPTION
- Add nftables docs to be generated
- Add a very simple example showing pulling from inet table

I was unable to get docs to build. Even before I made any changes. Maybe to help add CI + get building again unless I was causing the issue. README.md says use `make docs` but that's not a valid sphinx command. Do I need an older version?
```
(ip) cooper@home1:~/repos/pyroute2/docs$ make docs
make: *** No rule to make target 'docs'.  Stop.
```

Error with `make html`: https://pastebin.com/bM4jkvMk

Fixes  #747