### PR TITLE
support preferred_lft and valid_lft. fixes #752

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -1064,6 +1064,22 @@ class nlmsg_base(dict):
             for name, fmt in self.fields:
                 value = self[name]
 
+                if name == "ifa_valid":
+                    for a, v in self.parent.get("attrs", list()):
+                        if a == "IFA_VALID":
+                            value = v
+                            break
+                    else:
+                        value = pow(2, 32) - 1
+
+                if name == "ifa_preferred":
+                    for a, v in self.parent.get("attrs", list()):
+                        if a == "IFA_PREFERRED":
+                            value = v
+                            break
+                    else:
+                        value = pow(2, 32) - 1
+
                 if fmt == 's':
                     length = len(value)
                     efmt = '%is' % (length)
@@ -1427,6 +1443,13 @@ class nlmsg_base(dict):
         it is called from `encode()` routine.
         '''
         r_nla_map = self.__class__.__r_nla_map
+
+        if self.__class__.__name__ == "ifaddrmsg":
+            for name, _ in self.get("attrs", list()):
+                if name in ["IFA_PREFERRED", "IFA_VALID"]:
+                    self["attrs"].append(["IFA_CACHEINFO", True])
+                    break
+
         for i in range(len(self['attrs'])):
             cell = self['attrs'][i]
             if cell[0] in r_nla_map:


### PR DESCRIPTION
In this PR, we support valid lifetime and preferred lifetime for IPv6 addresses.  This fixes #752. 

The following example is now valid: 
```
from pyroute2 import IPRoute
with IPRoute() as ipr:
    ipr.link('add', ifname="dummy0", kind='dummy')
    idx = ipr.link_lookup(ifname="dummy0")[0]
    ipr.addr("add", index=idx, address="2001:db8::5678", mask=128, preferred=123, valid=456)
```

The above example yields the following result: 
```
7340: dummy0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 96:07:42:04:8a:15 brd ff:ff:ff:ff:ff:ff
    inet6 2001:db8::5678/128 scope global dynamic
       valid_lft 456sec preferred_lft 123sec
```

Both `preferred` and `valid` are new kwargs.  when unset the default value of "forever" is used.  Forever is defined by 2^32-1. 

This PR does not add any tests.  The testing suite seems quite complex and, in general, is broken on my machine. It fails when running `make test` on the head of master today.  Even adding a new test function that does nothing fails when running the single test as well.  I'm happy to update this PR if I can be given some guidance on how to get the tests working (ubuntu 20.04, python 3.8.5). 