### PR TITLE
fixed missing tcp diag info symbols

### DIFF
--- a/pyroute2/netlink/diag/__init__.py
+++ b/pyroute2/netlink/diag/__init__.py
@@ -214,7 +214,14 @@ class inet_diag_msg(inet_addr_codec):
                   ('tcpi_delivery_rate', 'Q'),
                   ('tcpi_busy_time', 'Q'),
                   ('tcpi_rwnd_limited', 'Q'),
-                  ('tcpi_sndbuf_limited', 'Q'))
+                  ('tcpi_sndbuf_limited', 'Q'),
+                  ('tcpi_delivered', 'I'),
+                  ('tcpi_delivered_ce', 'I'),
+                  ('tcpi_bytes_sent', 'Q'),
+                  ('tcpi_bytes_retrans', 'Q'),
+                  ('tcpi_dsack_dups', 'I'),
+                  ('tcpi_reord_seen', 'I'),
+                  ('tcpi_snd_wnd', 'I'))
 
         def decode(self):
             # Fix tcpi_rcv_scale amd delivery_rate bit fields.

--- a/pyroute2/netlink/diag/__init__.py
+++ b/pyroute2/netlink/diag/__init__.py
@@ -221,6 +221,7 @@ class inet_diag_msg(inet_addr_codec):
                   ('tcpi_bytes_retrans', 'Q'),
                   ('tcpi_dsack_dups', 'I'),
                   ('tcpi_reord_seen', 'I'),
+                  ('tcpi_rcv_ooopack', 'I'),
                   ('tcpi_snd_wnd', 'I'))
 
         def decode(self):


### PR DESCRIPTION
There were some symbols from `struct tcp_info` missing (c.f. `include/uapi/linux/tcp.h`). Those were added now.