### PR TITLE
Add End.BPF to seg6local

### DIFF
--- a/pyroute2/netlink/rtnl/req.py
+++ b/pyroute2/netlink/rtnl/req.py
@@ -220,6 +220,8 @@ class IPRouteRequest(IPRequest):
             srh = {}
             segs = []
             hmac = None
+            prog_fd = None
+            prog_name = None
             # Parse segs
             if srh:
                 segs = header['srh']['segs']
@@ -305,6 +307,10 @@ class IPRouteRequest(IPRequest):
                     # Add to ret the hmac key
                     srh['hmac'] = hmac & 0xffffffff
                 srh['mode'] = 'encap'
+            elif action == 'End.BPF':
+                prog_fd = header['bpf']['fd']
+                prog_name = header['bpf']['name']
+
             # Construct the new object
             ret = []
             ret.append(['SEG6_LOCAL_ACTION', {'value': action}])
@@ -326,6 +332,12 @@ class IPRouteRequest(IPRequest):
             if srh:
                 # Add the srh to ret
                 ret.append(['SEG6_LOCAL_SRH', srh])
+            if prog_fd and prog_name:
+                # Add the prog_fd and prog_name to ret
+                ret.append(['SEG6_LOCAL_BPF', {'attrs': [
+                    ['LWT_BPF_PROG_FD', prog_fd],
+                    ['LWT_BPF_PROG_NAME', prog_name],
+                ]}])
             # Done return the object
             return {'attrs': ret}
 

--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -345,7 +345,15 @@ class rtmsg_base(nlflags):
                    ('SEG6_LOCAL_NH6', 'nh6'),
                    ('SEG6_LOCAL_IIF', 'iif'),
                    ('SEG6_LOCAL_OIF', 'oif'),
-                   ('SEG6_LOCAL_BPF', 'none'))  # Actually not used
+                   ('SEG6_LOCAL_BPF', 'bpf_obj'))
+
+        class bpf_obj(nla):
+
+            __slots__ = ()
+
+            nla_map = (('LWT_BPF_PROG_UNSPEC', 'none'),
+                       ('LWT_BPF_PROG_FD', 'uint32'),
+                       ('LWT_BPF_PROG_NAME', 'asciiz'))
 
         class ipv6_sr_hdr(nla):
 


### PR DESCRIPTION
I want to use End.BPF seg6local function with pyroute2.

I saw modified version of https://github.com/Zashas/pyroute2/commit/6fa211a87375dc31bfacedbcb676047a66833c02.  It is partially merged in master of pyroute2, but partially not.

To use End.BPF with `fd` and `name`, I changed some code by refering modified version.

Here is use case of `End.BPF`:

```python3
from bcc import BPF
from pyroute2 import IPRoute

b = BPF(src_file="source.c")
fn = b.load_func("pass", 19)
# 19 means BPF_PROG_TYPE_LWT_SEG6LOCAL 
# https://github.com/torvalds/linux/blob/3cb12d27ff655e57e8efe3486dca2a22f4e30578/include/uapi/linux/bpf.h#L190

ipr = IPRoute()
idx = ipr.link_lookup(ifname=iface)[0]
sid = 'fd00::1/128'

encap = {'type':'seg6local', 'action':'End.BPF', 'bpf':{'fd':fn.fd, 'name':fn.name}}
ipr.route("add", dst=sid, oif=idx, encap=encap)
```

source.c:
```source.c
#include <linux/bpf.h>

int pass(struct __sk_buff *skb) {
    return BPF_OK; // packet continues
}
```