### PR TITLE
WIP : Extended ack support

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -524,6 +524,9 @@ NLM_F_EXCL = 0x200    # Do not touch, if it exists
 NLM_F_CREATE = 0x400    # Create, if it does not exist
 NLM_F_APPEND = 0x800    # Add to end of list
 
+NLM_F_CAPPED = 0x100
+NLM_F_ACK_TLVS = 0x200
+
 NLMSG_NOOP = 0x1    # Nothing
 NLMSG_ERROR = 0x2    # Error
 NLMSG_DONE = 0x3    # End of a dump
@@ -567,6 +570,7 @@ NETLINK_RX_RING = 6
 NETLINK_TX_RING = 7
 
 NETLINK_LISTEN_ALL_NSID = 8
+NETLINK_EXT_ACK	= 11
 
 clean_cbs = threading.local()
 
@@ -2057,6 +2061,20 @@ class nlmsg(nlmsg_atoms):
               ('flags', 'H'),
               ('sequence_number', 'I'),
               ('pid', 'I'))
+
+
+class nlmsgerr(nlmsg):
+    '''
+    Extended ack error message
+    '''
+
+    __slots__ = ()
+
+    fields = (('error', 'i'),)
+
+    nla_map = (('NLMSGERR_ATTR_UNUSED', 'none'),
+               ('NLMSGERR_ATTR_MSG', 'asciiz'),
+               ('NLMSGERR_ATTR_OFFS', 'uint32'))
 
 
 class genlmsg(nlmsg):

--- a/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
@@ -442,10 +442,12 @@ class ifinfbase(object):
                ('IFLA_XDP', 'hex'),
                ('IFLA_EVENT', 'hex'),
                ('IFLA_NEW_NETNSID', 'hex'),
-               ('IFLA_IF_NETNSID', 'hex'),
+               ('IFLA_IF_NETNSID', 'uint32'),
                ('IFLA_CARRIER_UP_COUNT', 'uint32'),
                ('IFLA_CARRIER_DOWN_COUNT', 'uint32'),
-               ('IFLA_NEW_IFINDEX', 'hex'))
+               ('IFLA_NEW_IFINDEX', 'hex'),
+               ('IFLA_MIN_MTU', 'uint32'),
+               ('IFLA_MAX_MTU', 'uint32'))
 
     @staticmethod
     def flags2names(flags, mask=0xffffffff):


### PR DESCRIPTION
Hello Peter,

During some debug with kernel netlink messages, it appears to us that extended ack support could be a great feature in pyroute2, allowing to read more useful error messages.

I wrote in this MR a proof of concept of how it's working, that one can reproduce with :

```python
In [1]: from pyroute2 import IPRoute

In [2]: ipr = IPRoute(ext_ack=True)

In [3]: ipr.link("dump", if_netnsid=4)  # here 4 must be an invalid netns number
{'error': -22, 'attrs': [('NLMSGERR_ATTR_MSG', 'Invalid target network namespace id')], 'header': {'length': 60, 'type': 3, 'flags': 514, 'sequence_number': 255, 'pid': 30621}}
```

However, there are still a lot of work before to be able to merge it. I didn't find a good way to parse standard nlmsg as nlmsgerr when NLM_F_ACK_TLVS flah is set.

And there are a lot of missing feature, like capped messages, cookies, etc. But I have currently no idea of the best idea to go forward. Could you have a look on it?