### PR TITLE
Ignore other encap_types load_netlink

### DIFF
--- a/pyroute2/ipdb/routes.py
+++ b/pyroute2/ipdb/routes.py
@@ -350,15 +350,13 @@ class BaseRoute(Transactional):
                         self['multipath'].add(nh)
                 elif norm == 'encap':
                     with self['encap']._direct_state:
-                        ret = []
-                        # FIXME: should support encap_types other than MPLS
-                        try:
+                        # WIP: should support encap_types other than MPLS
+                        if value.get_attr('MPLS_IPTUNNEL_DST'):
+                            ret = []
                             for dst in value.get_attr('MPLS_IPTUNNEL_DST'):
                                 ret.append(str(dst['label']))
                             if ret:
                                 self['encap']['labels'] = '/'.join(ret)
-                        except AttributeError:
-                            pass
                 elif norm == 'via':
                     with self['via']._direct_state:
                         self['via'] = value


### PR DESCRIPTION
Hi,

I want to use the End.BPF seg6local endpoint; @kyontan already discussed that in his pull request 1d73ed4595529b3d80199aaa80dfa4b46bfdc414.

However, if the `encap` was not MPLS, the code crashed because we try to iterate over a `None` object. the current try-catch does not handle that, as the `get_attr` returns a default valu and does not raise an error.

Maybe support for other encapsulations should be added, but it works like this for the End.BPF now.