### PR TITLE
[NDB] Change warning to work with Python < 3.6

### DIFF
--- a/pyroute2/ndb/main.py
+++ b/pyroute2/ndb/main.py
@@ -304,7 +304,7 @@ class Transaction(object):
                     try:
                         rb.rollback()
                     except Exception as e:
-                        self.log.warning(f'ignore rollback exception: {e}')
+                        self.log.warning('ignore rollback exception: %s' % e)
                 raise
         self.event.set()
         return self


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

#### [NDB] Change warning to work with Python < 3.6

### Summary

In the latest 0.5.15 [this line](https://github.com/svinota/pyroute2/blame/master/pyroute2/ndb/main.py#L307) has been included which work on `Python >= 3.6` but not on `Python < 3.6`

Simple fix, change the way to inject the var in the warning.