### PR TITLE
ss2: align license with overall libary project

### DIFF
--- a/cli/ss2
+++ b/cli/ss2
@@ -1,19 +1,21 @@
 #!/usr/bin/env python
+
 # pyroute2 - ss2
 # Copyright (C) 2018  Matthias Tafelmeier
-
-# ss2 is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
-# ss2 is distributed in the hope that it will be useful,
+#
+# ss2 is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+# 
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
 
 import json
 import socket


### PR DESCRIPTION
Moving to GPL v2 character of licensing on request
of main maintainer.