### PR TITLE
Fix file descriptors leak

### DIFF
--- a/pyroute2/netns/process/proxy.py
+++ b/pyroute2/netns/process/proxy.py
@@ -8,6 +8,7 @@ namespace support.
 
 '''
 
+import os
 import sys
 import fcntl
 import types
@@ -289,6 +290,10 @@ class NSPopen(ObjNS):
             self.channel_out.close()
             self.channel_in.close()
             self.server.join()
+            # clean leftover pipes that would be closed at program exit
+            os.close(self.server.sentinel)
+            self.channel_out._writer.close()
+            self.channel_in._writer.close()
 
     def __dir__(self):
         return list(self.api.keys()) + ['release']


### PR DESCRIPTION
Intensive usage of pyroute2 over long period of time creates excessive
amount of leftover file descriptors. Those would normally be cleaned at
program exit, but in long running services that is not an option.
To prevent that behavior this patch explicitly closes pipes created with
multiprocessing.popen_fork.Popen._launch when they are no longer needed.

Signed-off-by: Michal Zylowski <michal.zylowski@ovhcloud.com>

Bug-Url: https://github.com/svinota/pyroute2/issues/622


Related to #622 