### PR TITLE
Fixed "python" in for make README.md rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ dist: force-version docs
 	@${python} setup.py sdist >/dev/null 2>&1
 
 README.md:
-	@cat README.rst | python ./docs/conv.py >README.md
+	@cat README.rst | ${python} ./docs/conv.py >README.md
 
 install: clean force-version README.md
 	${python} setup.py install ${root} ${lib}


### PR DESCRIPTION
Fixed #783

When trying to install this on systems the don't have unqualified 'python' (ie no version specified) executable you get an error:

```
# make install python=/usr/bin/python3
/bin/sh: python: command not found
make: *** [Makefile:175: README.md] Error 127
```

My guess is this was a typo and it was intended to use '${python}' for this rule instead, so I fixed it.