### PR TITLE
Increase DEFAULT_RCVBUF size to support 127 VFs

### DIFF
--- a/pyroute2.core/pr2modules/common.py
+++ b/pyroute2.core/pr2modules/common.py
@@ -39,7 +39,7 @@ except NameError:
 
 AF_MPLS = 28
 AF_PIPE = 255  # Right now AF_MAX == 40
-DEFAULT_RCVBUF = 32768
+DEFAULT_RCVBUF = 65536
 _uuid32 = 0  # (singleton) the last uuid32 value saved to avoid collisions
 _uuid32_lock = threading.Lock()
 


### PR DESCRIPTION
Increase the DEFAULT_RCVBUF size from 32K to 64K to allow more data
to be passed along with newer kernels.

Fixes #813