### PR TITLE
ipset: add missing mac support for ipset content

### DIFF
--- a/pyroute2.ipset/pr2modules/wiset.py
+++ b/pyroute2.ipset/pr2modules/wiset.py
@@ -251,6 +251,8 @@ class WiSet(object):
                         proto = IP_PROTOCOLS.get(proto, str(proto)).lower()
                         key += '{proto}:'.format(proto=proto)
                     key += str(entry.get_attr("IPSET_ATTR_PORT_FROM"))
+                elif parse_type == "mac":
+                    key += entry.get_attr("IPSET_ATTR_ETHER")
                 key += ","
 
             key = key.strip(",")


### PR DESCRIPTION
The [`update_dict_content`](https://github.com/svinota/pyroute2/blob/29e15d854b75653cd1400cbbac230dd5298648ac/pyroute2.ipset/pr2modules/wiset.py#L233-L253) method does currently not handle `mac` types. This create wrong results when calling `wiset.load_ipset('..').content` since all entries are mapped to a empty key (if using an `hash:mac` ipset).
