### PR TITLE
[core] Fix BPF encap handling in IPRouteRequest filter

### DIFF
--- a/pyroute2.core/pr2modules/netlink/rtnl/req.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/req.py
@@ -213,7 +213,7 @@ class IPRouteRequest(IPRequest):
                     if 'headroom' in value:
                         attrs['LWT_BPF_XMIT_HEADROOM'] = value['headroom']
 
-            return {'attrs': attrs.items()}
+            return {'attrs': list(attrs.items())}
         '''
         Seg6 encap header transform. Format samples:
 


### PR DESCRIPTION
```
Traceback (most recent call last):
...
  File "/nix/store/jqlhx84p232pja1bcwdc3higlwj7f0fp-python3.9-pyroute2-core-0.6.4/lib/python3.9/site-packages/pr2modules/iproute/linux.py", line 1969, in route
    ret = self.nlm_request(msg,
  File "/nix/store/jqlhx84p232pja1bcwdc3higlwj7f0fp-python3.9-pyroute2-core-0.6.4/lib/python3.9/site-packages/pr2modules/netlink/nlsocket.py", line 391, in nlm_request
    return tuple(self._genlm_request(*argv, **kwarg))
  File "/nix/store/jqlhx84p232pja1bcwdc3higlwj7f0fp-python3.9-pyroute2-core-0.6.4/lib/python3.9/site-packages/pr2modules/netlink/nlsocket.py", line 881, in nlm_request
    self.put(msg, msg_type, msg_flags, msg_seq=msg_seq)
  File "/nix/store/jqlhx84p232pja1bcwdc3higlwj7f0fp-python3.9-pyroute2-core-0.6.4/lib/python3.9/site-packages/pr2modules/netlink/nlsocket.py", line 630, in put
    self.sendto_gate(msg, addr)
  File "/nix/store/hzcfanby9xpnvh3qszpw1s8zqdcawkcg-python3.9-pyroute2-nslink-0.6.4/lib/python3.9/site-packages/pr2modules/remote/transport.py", line 237, in _gate
    pickle.dumps(msg.dump()),
TypeError: cannot pickle 'dict_items' object
```