### PR TITLE
Fix compat with Sphinx 4.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,4 +46,4 @@ texinfo_documents = [('index',
 
 
 def setup(app):
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')


### PR DESCRIPTION
Pyroute2 conf.py is still using app.add_stylesheet() which was deprecated in
the favor of app.add_css_file(). In 4.x, app.add_stylesheet() was completely
removed, rendering Pyroute2's doc incompatible with Sphinx 4.x This patch
fixes it.