### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyroute2.core/pr2modules/netlink/rtnl/iw_event.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/iw_event.py
@@ -57,7 +57,7 @@ class iw_event(nla):
                # and multicast)
                (0xB2C, 'SIOCSIWPOWER', 'hex'),
                (0xB2D, 'SIOCGIWPOWER', 'hex'),
-               # WPA : Generic IEEE 802.11 informatiom element
+               # WPA : Generic IEEE 802.11 information element
                # (e.g., for WPA/RSN/WMM).
                (0xB30, 'SIOCSIWGENIE', 'hex'),
                (0xB31, 'SIOCGIWGENIE', 'hex'),

--- a/pyroute2.ipdb/pr2modules/ipdb/main.py
+++ b/pyroute2.ipdb/pr2modules/ipdb/main.py
@@ -214,7 +214,7 @@ managers in the same way as IPDB does itself::
         i.add_ip('10.0.0.1', 24)
         i.add_ip('10.0.0.1', 24)
 
-On exit, the context manager will authomatically `commit()`
+On exit, the context manager will automatically `commit()`
 the transaction.
 
 Read-only interface views
@@ -275,7 +275,7 @@ notation, or a pair of `'address', mask`::
         eth.del_ip('172.16.12.5', 24)
 
 The `ipaddr` attribute contains all the IP addresses of the
-interface, which are acessible in different ways. Getting an
+interface, which are accessible in different ways. Getting an
 iterator from `ipaddr` gives you a sequence of tuples
 `('address', mask)`::
 
@@ -1098,7 +1098,7 @@ class IPDB(object):
         '''
         Initializes event queue and returns event queue context manager.
         Once the context manager is initialized, events start to be collected,
-        so it is possible to read initial state from the system witout losing
+        so it is possible to read initial state from the system without losing
         last moment changes, and once that is done, start processing events.
 
         Example:

--- a/pyroute2.ipset/pr2modules/ipset.py
+++ b/pyroute2.ipset/pr2modules/ipset.py
@@ -292,7 +292,7 @@ class IPSet(NetlinkSocket):
             return attrs
 
         # We support string (for one element, and for users calling this
-        # function like a command line), and tupple/list
+        # function like a command line), and tuple/list
         if isinstance(entry, basestring):
             entry = entry.split(',')
         if isinstance(entry, (int, PortRange, PortEntry)):

--- a/pyroute2.ndb/pr2modules/ndb/main.py
+++ b/pyroute2.ndb/pr2modules/ndb/main.py
@@ -147,7 +147,7 @@ Change an interface property::
     with ndb.interfaces['eth0'] as i:
         i['state'] = 'up'
         i['address'] = '00:11:22:33:44:55'
-    # ---> <---  the commit() is called authomatically by
+    # ---> <---  the commit() is called automatically by
     #            the context manager's __exit__()
 
 '''

--- a/pyroute2.ndb/pr2modules/ndb/report.py
+++ b/pyroute2.ndb/pr2modules/ndb/report.py
@@ -276,7 +276,7 @@ class RecordSet(BaseRecordSet):
             * prefix -- rename the "right" fields using the prefix
 
         The condition function must have two arguments, left record and
-        rigth record, and must return True or False. The routine discards
+        right record, and must return True or False. The routine discards
         joined records when the condition is False.
 
         Example, provide interface names for routes, don't change field


### PR DESCRIPTION
There are small typos in:
- pyroute2.core/pr2modules/netlink/rtnl/iw_event.py
- pyroute2.ipdb/pr2modules/ipdb/main.py
- pyroute2.ipset/pr2modules/ipset.py
- pyroute2.ndb/pr2modules/ndb/main.py
- pyroute2.ndb/pr2modules/ndb/report.py

Fixes:
- Should read `automatically` rather than `authomatically`.
- Should read `without` rather than `witout`.
- Should read `tuple` rather than `tupple`.
- Should read `right` rather than `rigth`.
- Should read `information` rather than `informatiom`.
- Should read `accessible` rather than `acessible`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md