### PR TITLE
Conntrack kernel side filtering

### DIFF
--- a/pyroute2.core/pr2modules/conntrack.py
+++ b/pyroute2.core/pr2modules/conntrack.py
@@ -162,7 +162,8 @@ class Conntrack(NFCTSocket):
                                              daddr='8.8.8.8')):
                 print("This entry is icmp to 8.8.8.8: {}".format(entry))
         """
-        for ndmsg in self.dump(mark=mark, mark_mask=mark_mask):
+        for ndmsg in self.dump(mark=mark, mark_mask=mark_mask, tuple_orig=tuple_orig,
+                               tuple_reply=tuple_reply):
 
             if tuple_orig is not None and not tuple_orig.nla_eq(
                     ndmsg['nfgen_family'], ndmsg.get_attr('CTA_TUPLE_ORIG')):

--- a/pyroute2.core/pr2modules/netlink/nfnetlink/nfctsocket.py
+++ b/pyroute2.core/pr2modules/netlink/nfnetlink/nfctsocket.py
@@ -6,6 +6,7 @@ See also: pr2modules.conntrack
 
 import socket
 
+from pr2modules.netlink import NLA_F_NESTED
 from pr2modules.netlink import NLMSG_ERROR
 from pr2modules.netlink import NLM_F_REQUEST
 from pr2modules.netlink import NLM_F_DUMP
@@ -339,6 +340,7 @@ class nfct_msg(nfgen_msg):
         )
 
     class cta_filter(nla):
+        nla_flags = NLA_F_NESTED
         nla_map = (
             ('CTA_FILTER_UNSPEC', 'none'),
             ('CTA_FILTER_ORIG_FLAGS', 'uint32'),

--- a/pyroute2.core/pr2modules/netlink/nfnetlink/nfctsocket.py
+++ b/pyroute2.core/pr2modules/netlink/nfnetlink/nfctsocket.py
@@ -684,8 +684,10 @@ class NFCTSocket(NetlinkSocket):
                 'attrs': [['CTA_FILTER_REPLY_FLAGS', tuple_reply.flags]]
             }
             msg = nfct_msg.create_from(tuple_reply=tuple_reply, cta_filter=cta_filter)
-        else:
+        elif mark:
             msg = nfct_msg.create_from(mark=mark, mark_mask=mark_mask)
+        else:
+            msg = nfct_msg.create_from()
         return self.request(msg, IPCTNL_MSG_CT_GET,
                             msg_flags=NLM_F_REQUEST | NLM_F_DUMP)
 

--- a/pyroute2.core/pr2modules/netlink/nfnetlink/nfctsocket.py
+++ b/pyroute2.core/pr2modules/netlink/nfnetlink/nfctsocket.py
@@ -644,6 +644,34 @@ class NFCTSocket(NetlinkSocket):
         return self.nlm_request(msg, msg_type, **kwargs)
 
     def dump(self, mark=None, mark_mask=0xffffffff, tuple_orig=None, tuple_reply=None):
+        """ Dump conntrack entries
+
+        Several kernel side filtering are supported:
+          * mark and mark_mask, for almost all kernel
+          * tuple_orig and tuple_reply, since kernel 5.8 and newer.
+            Warning: tuple_reply has a bug in kernel, fixed only recently.
+
+        tuple_orig and tuple_reply are type NFCTAttrTuple.
+        You can give only some attribute for filtering.
+
+        Example::
+            # Get only connections from 192.168.1.1
+            filter = NFCTAttrTuple(saddr='192.168.1.1')
+            ct.dump_entries(tuple_orig=filter)
+
+            # Get HTTPS connections
+            filter = NFCTAttrTuple(proto=socket.IPPROTO_TCP, dport=443)
+            ct.dump_entries(tuple_orig=filter)
+
+        Note that NFCTAttrTuple attributes are working like one AND operator.
+
+        Example::
+           # Get connections from 192.168.1.1 AND on port 443
+           TCP = socket.IPPROTO_TCP
+           filter = NFCTAttrTuple(saddr='192.168.1.1', proto=TCP, dport=443)
+           ct.dump_entries(tuple_orig=filter)
+
+        """
         if tuple_orig is not None:
             tuple_orig.attrs() # for creating flags
             cta_filter = {


### PR DESCRIPTION
Hello,

Sorry for the lag, we developed this feature two years ago but we never use it before today.
So, this is an implementation for kernel side filtering (again !) on conntracks. As you may imagine, performance boost is huge on routers with large number of conntracks.

Sadly, we introduced a bug in kernel so tuple_reply is not working as excepted. But that should be fixed soon