### PR TITLE
Add support for the SRv6 End.DT4 behavior

### DIFF
--- a/pyroute2.core/pr2modules/iproute/linux.py
+++ b/pyroute2.core/pr2modules/iproute/linux.py
@@ -1887,6 +1887,20 @@ class RTNL_API(object):
                             'action': 'End.DT6',
                             'table':'10'})
 
+        Create SEG6LOCAL tunnel End.DT4 action (kernel >= 5.11)::
+            # $ sudo modprobe vrf
+            # $ sudo sysctl -w net.vrf.strict_mode=1
+            ip.link('add',
+                    ifname='vrf-foo',
+                    kind='vrf',
+                    vrf_table=10)
+            ip.route('add',
+                     dst='2001:0:0:10::2/128',
+                     oif=idx,
+                     encap={'type': 'seg6local',
+                            'action': 'End.DT4',
+                            'vrf_table': 10})
+
         Create SEG6LOCAL tunnel End.B6 action (kernel >= 4.14)::
 
             ip.route('add',

--- a/pyroute2.core/pr2modules/netlink/rtnl/req.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/req.py
@@ -222,6 +222,10 @@ class IPRouteRequest(IPRequest):
              'table': '10'}
 
             {'type': 'seg6local',
+             'action': 'End.DT4',
+             'vrf_table': 10}
+
+            {'type': 'seg6local',
              'action': 'End.B6',
              'table': '10'
              'srh': {'segs': '2000::5,2000::6'}}

--- a/pyroute2.core/pr2modules/netlink/rtnl/req.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/req.py
@@ -239,6 +239,7 @@ class IPRouteRequest(IPRequest):
             hmac = None
             prog_fd = None
             prog_name = None
+            vrf_table = None
             # Parse segs
             if srh:
                 segs = header['srh']['segs']
@@ -277,8 +278,8 @@ class IPRouteRequest(IPRequest):
                 # Retrieve table
                 table = header['table']
             elif action == 'End.DT4':
-                # Retrieve table
-                table = header['table']
+                # Retrieve vrf_table
+                vrf_table = header['vrf_table']
             elif action == 'End.B6':
                 # Parse segs
                 segs = header['srh']['segs']
@@ -334,6 +335,9 @@ class IPRouteRequest(IPRequest):
             if table:
                 # Add the table to ret
                 ret.append(['SEG6_LOCAL_TABLE', {'value': table}])
+            if vrf_table:
+                # Add the vrf_table to ret
+                ret.append(['SEG6_LOCAL_VRFTABLE', {'value': vrf_table}])
             if nh4:
                 # Add the nh4 to ret
                 ret.append(['SEG6_LOCAL_NH4', {'value': nh4}])
@@ -489,6 +493,10 @@ class IPRouteRequest(IPRequest):
                 # 'encap': {'type': 'seg6local',
                 #           'action': 'End.DT6',
                 #           'table': '10'}
+                #
+                # 'encap': {'type': 'seg6local',
+                #           'action': 'End.DT4',
+                #           'vrf_table': 10}
                 #
                 # 'encap': {'type': 'seg6local',
                 #           'action': 'End.DX6',

--- a/pyroute2.core/pr2modules/netlink/rtnl/rtmsg.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/rtmsg.py
@@ -347,7 +347,8 @@ class rtmsg_base(nlflags):
                    ('SEG6_LOCAL_NH6', 'nh6'),
                    ('SEG6_LOCAL_IIF', 'iif'),
                    ('SEG6_LOCAL_OIF', 'oif'),
-                   ('SEG6_LOCAL_BPF', 'bpf_obj'))
+                   ('SEG6_LOCAL_BPF', 'bpf_obj'),
+                   ('SEG6_LOCAL_VRFTABLE', 'vrf_table'))
 
         class bpf_obj(nla):
 
@@ -608,6 +609,13 @@ class rtmsg_base(nlflags):
                 nla_string.decode(self)
                 # Convert the packed IP address to its string representation
                 self['value'] = inet_ntop(AF_INET6, self['value'])
+
+        class vrf_table(nla):
+
+            __slots__ = ()
+
+            # VRF Table ID
+            fields = (('value', 'I'),)
 
     #
     # TODO: add here other lwtunnel types


### PR DESCRIPTION
This PR adds the support for the _SRv6 End.DT4 behavior_.

The SRv6 End.DT4 behavior is used to implement IPv4 L3VPN use-cases in multi-tenants environments. It decapsulates the received packets and performs IPv4 routing lookup in the routing table of the tenant.

The SRv6 End.DT4 behavior has been introduced in the Linux kernel in the commit [1] and it is available since kernel version 4.11.
The _iproute2_ suite has been extended as well for supporting the SRv6 End.DT4 behavior [2].

An example iproute2 command to instantiate an SRv6 End.DT4 behavior is the following:

`$ ip route add 2001:db8::1 encap seg6local action End.DT4 vrftable 100 dev eth0`

In the above command, the `vrftable` attribute indicates the routing table associated with the VRF device used by SRv6 End.DT4 for routing IPv4 packets.

In order to support SRv6 End.DT4 in pyroute2, we introduce the `vrf_table` attribute.


The only prerequisite to instantiate an End.DT4 behavior is enabling the VRF strict_mode sysctl parameter:

`$ sysctl -wq net.vrf.strict_mode=1`


Hereafter, we provide an example of how to instantiate an SRv6 End.DT4 behavior with pyroute2.

First, a VRF needs to be created:

```
ip.link('add',
        ifname='vrf-foo',
        kind='vrf',
        vrf_table=100)
```

Then, the following command can be used to instantiate the behavior:

```
ip.route('add',
         dst='2001:db8::1/128',
         oif=idx,
         encap={'type': 'seg6local',
                'action': 'End.DT4',
                'vrf_table': 100})
```

---
[1] https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=664d6f86868b
[2] https://www.spinics.net/lists/netdev/msg707082.html
