### PR TITLE
Fixed NetNS.brport and brport('set')

### DIFF
--- a/pyroute2.core/pr2modules/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/ifinfmsg/__init__.py
@@ -754,10 +754,13 @@ class ifinfbase(object):
         def info_slave_data(self, *argv, **kwarg):
             '''
             Return IFLA_INFO_SLAVE_DATA type based on
-            IFLA_INFO_SLAVE_KIND.
+            IFLA_INFO_SLAVE_KIND or IFLA_INFO_KIND.
             '''
             kind = self.get_attr('IFLA_INFO_SLAVE_KIND')
+            if kind is None:
+                kind = self.get_attr('IFLA_INFO_KIND')
             data_map = {'bridge': self.bridge_slave_data,
+                        'bridge_slave': self.bridge_slave_data,
                         'bond': self.bond_slave_data}
             return data_map.get(kind, self.hex)
 
@@ -960,7 +963,8 @@ class ifinfbase(object):
                     'ip6gre': ip6gre_data,
                     'ip6gretap': ip6gre_data,
                     'veth': veth_data,
-                    'bridge': bridge_data}
+                    'bridge': bridge_data,
+                    'bridge_slave': bridge_slave_data}
         # expand supported interface types
         data_map.update(data_plugins)
 

--- a/pyroute2.core/pr2modules/netlink/rtnl/req.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/req.py
@@ -649,6 +649,7 @@ class IPLinkRequest(IPRequest):
         self.specific = {}
         self.linkinfo = None
         self._info_data = None
+        self._info_slave_data = None
         IPRequest.__init__(self, *argv, **kwarg)
         if 'index' not in self:
             self['index'] = 0
@@ -660,6 +661,14 @@ class IPLinkRequest(IPRequest):
             self._info_data = info_data[1]['attrs']
             self.linkinfo.append(info_data)
         return self._info_data
+
+    @property
+    def info_slave_data(self):
+        if self._info_slave_data is None:
+            info_slave_data = ('IFLA_INFO_SLAVE_DATA', {'attrs': []})
+            self._info_slave_data = info_slave_data[1]['attrs']
+            self.linkinfo.append(info_slave_data)
+        return self._info_slave_data
 
     def flush_deferred(self):
         # create IFLA_LINKINFO
@@ -743,7 +752,11 @@ class IPLinkRequest(IPRequest):
                 raise ValueError()
         # the kind is known: lookup the NLA
         if key in self.specific:
-            self.info_data.append((self.specific[key], value))
+            # FIXME: slave hack
+            if self.kind.endswith('_slave'):
+                self.info_slave_data.append((self.specific[key], value))
+            else:
+                self.info_data.append((self.specific[key], value))
             return True
         elif key == 'peer' and self.kind == 'veth':
             # FIXME: veth hack


### PR DESCRIPTION
- Fixed `brport` command via `NetNS`
The issue was caused by using `IPBrPortRequest` directly and not just as an attribute filter. When the netns server tried to reconstruct the `IPBrPortRequest` object the `allowed` property did not exist yet
Fixes #864 
- Added `IPRoute.link` initial slave support
iproute2 can set slave options like this:
`ip link set dev <devname> type <type>_slave <options...>`
Since IPRoute.link command already handles `IFLA_INFO_DATA` creation it was easier to modify it to support `IFLA_INFO_SLAVE_DATA` too. For this to work `ifinfmsg` must have been updated to handle slave options (currently only `bridge_slave`)
- Rewritten `IPRoute.brport('set', ...)` to use `IPRoute.link('set', kind='bridge_slave', ...)`
Since `IPRoute.link` is now capable to handle slave options `brport('set')` is just became a wrapper for it. I left other commands alone for compatibility