### PR TITLE
Fix occasional crashes in NSPopen.release

### DIFF
--- a/pyroute2.nslink/pr2modules/nslink/nspopen.py
+++ b/pyroute2.nslink/pr2modules/nslink/nspopen.py
@@ -8,7 +8,6 @@ namespace support.
 
 '''
 
-import os
 import sys
 import fcntl
 import types
@@ -339,9 +338,9 @@ class NSPopen(ObjNS):
             self.channel_in.close()
             self.server.join()
             # clean leftover pipes that would be closed at program exit
-            os.close(self.server.sentinel)
-            self.channel_out._writer.close()
-            self.channel_in._writer.close()
+            del self.server
+            del self.channel_out
+            del self.channel_in
 
     def __dir__(self):
         return list(self.api.keys()) + ['release']


### PR DESCRIPTION
Fix for the issue that NSPopen's release() occasionally crashes
with an OSError / "Bad File Descriptor" inside
self.channel_out._writer.close().
To still avoid the file descriptor leak in multiprocessing.Queue
but be more robust: Switch from closing the writer explicity to
deleting the Queue object.

Fixes #871