### PR TITLE
IPDB: Interface Address AF_INET6

### DIFF
--- a/pyroute2.ipdb/pr2modules/ipdb/interfaces.py
+++ b/pyroute2.ipdb/pr2modules/ipdb/interfaces.py
@@ -1407,7 +1407,9 @@ class AddressesDict(dict):
         if msg['family'] == AF_INET:
             addr = msg.get_attr('IFA_LOCAL')
         elif msg['family'] == AF_INET6:
-            addr = msg.get_attr('IFA_ADDRESS')
+            addr = msg.get_attr('IFA_LOCAL')
+            if not addr:
+                addr = msg.get_attr('IFA_ADDRESS')
         else:
             return
         raw = {


### PR DESCRIPTION
On Point to Point connections like PPPoE the local ip address
is in IFA_LOCAL and not in IFA_ADDRESS.
IFA_ADDRESS is the remote ip address in that case.
Check for IFA_LOCAL first before using IFA_ADDRESS.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>