### PR TITLE
Fix encoding of nested/array NLAs

### DIFF
--- a/pyroute2.core/pr2modules/netlink/__init__.py
+++ b/pyroute2.core/pr2modules/netlink/__init__.py
@@ -1064,14 +1064,15 @@ class nlmsg_base(dict):
             for value in self.getvalue():
                 cell = type(self)(data=self.data, offset=offset, parent=self)
                 cell._nla_array = False
-                cell['header']['type'] = self.header_type or (
-                    header_type | self._nla_flags
-                )
-                header_type += 1
 
                 if cell.cell_header is not None:
                     cell.header = cell.cell_header
                 cell.setvalue(value)
+                # overwrite header type after calling setvalue
+                cell['header']['type'] = self.header_type or (
+                    header_type | self._nla_flags
+                )
+                header_type += 1
                 cell.encode()
                 offset += (cell.length + 4 - 1) & ~(4 - 1)
         elif self.getvalue() is not None:
@@ -1340,10 +1341,11 @@ class nlmsg_base(dict):
                 if isinstance(cell, tuple) and len(cell) > 2:
                     nla_instance._nla_flags |= cell[2]
                 nla_instance._nla_array = prime['nla_array']
+                nla_instance.setvalue(cell[1])
+                # overwrite header type after calling setvalue
                 nla_instance['header']['type'] = (
                     prime['type'] | nla_instance._nla_flags
                 )
-                nla_instance.setvalue(cell[1])
                 try:
                     nla_instance.encode()
                 except:


### PR DESCRIPTION
[`nlmsg_base.setvalue`][1] overwrites the header if the value is a dict, and all classes derived from `nla` are such dicts.

[`nlmsg_base.encode`][2] first sets nested header type to the index for array entries; the following call to `setvalue` will remove the type, so all entries end up with index 0 (which the kernel won't accept, resulting in `EINVAL`).

[`nlmsg_base.encode_nlas`][3] has the same issue; it first sets sets the header type and then calls `setvalue`, so the encoded NLA will end up having a header type 0 (and the kernel will probably ignore the NLA).

Perhaps `nft` is the only compex enough subsystem to use those features, otherwise I can't see how nobody had issues with this before... (I'm using the low-level types from `pr2modules.netlink.nfnetlin`k to modify nftable sets, and `NFTA_SET_ELEM_KEY` and `NFTA_SET_ELEM_LIST_ELEMENTS` attributes fail to encode properly without this).

As a workaround one can monkey-patch `setvalue` to merge the header subdict instead of overwriting it:
```python
def _monkey_patch_pyroute2():
    import pr2modules.netlink
    # overwrite setdefault on nlmsg_base class hierarchy
    _orig_setvalue = pr2modules.netlink.nlmsg_base.setvalue

    def _nlmsg_base__setvalue(self, value):
        if not self.header or not self['header'] or not isinstance(value, dict):
            return _orig_setvalue(self, value)
        header = value.pop('header', {})
        res = _orig_setvalue(self, value)
        self['header'].update(header)
        return res

    def overwrite_methods(cls: typing.Type) -> None:
        if cls.setvalue is _orig_setvalue:
            cls.setvalue = _nlmsg_base__setvalue
            for subcls in cls.__subclasses__():
                overwrite_methods(subcls)

    overwrite_methods(pr2modules.netlink.nlmsg_base)
```

[1]: https://github.com/svinota/pyroute2/blob/cec1c4b6d6f5ecbd82a024648a767a10663eb35e/pyroute2.core/pr2modules/netlink/__init__.py#L1094-L1096
[2]: https://github.com/svinota/pyroute2/blob/cec1c4b6d6f5ecbd82a024648a767a10663eb35e/pyroute2.core/pr2modules/netlink/__init__.py#L1067-L1074
[3]: https://github.com/svinota/pyroute2/blob/cec1c4b6d6f5ecbd82a024648a767a10663eb35e/pyroute2.core/pr2modules/netlink/__init__.py#L1343-L1346