### PR TITLE
nftables: Fix nftables expressions

### DIFF
--- a/pyroute2.core/pr2modules/netlink/nfnetlink/nftsocket.py
+++ b/pyroute2.core/pr2modules/netlink/nfnetlink/nftsocket.py
@@ -900,9 +900,10 @@ class nft_table_msg(nfgen_msg, nft_contains_expr):
 
 
 class nft_set_elem_list_msg(nfgen_msg):
+    prefix = 'NFTA_SET_ELEM_LIST_'
     nla_map = (
         ('NFTA_SET_ELEM_LIST_UNSPEC', 'none'),
-        ('NFTA_SET_TABLE', 'asciiz'),
+        ('NFTA_SET_ELEM_LIST_TABLE', 'asciiz'),
         ('NFTA_SET_ELEM_LIST_SET', 'asciiz'),
         ('NFTA_SET_ELEM_LIST_ELEMENTS', '*set_elem'),
         ('NFTA_SET_ELEM_LIST_SET_ID', 'be32'),

--- a/pyroute2.core/pr2modules/netlink/nfnetlink/nftsocket.py
+++ b/pyroute2.core/pr2modules/netlink/nfnetlink/nftsocket.py
@@ -653,7 +653,7 @@ class nft_contains_expr:
             class quota_flags(nft_flags_be32):
                 ops = ('NFT_QUOTA_F_INV', 'NFT_QUOTA_F_DEPLETED')
 
-        class nft_range(nft_regs):
+        class nft_range(nft_regs, nft_data):
             nla_map = (
                 ('NFTA_RANGE_UNSPEC', 'none'),
                 ('NFTA_RANGE_SREG', 'regs'),


### PR DESCRIPTION
When decoding nftables rules with ranges (`pprint.pprint(pyroute2.NFTables(nfgen_family=1).get_rules())`), it fails with the following exception:
```
Traceback (most recent call last):
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1439, in ft_decode
    self.decode_nlas(offset)
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1386, in decode_nlas
    nla_instance = msg_class(
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 734, in __init__
    self.compile_nla()
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1302, in compile_nla
    nla_class = getattr(self, nla_class)
AttributeError: 'nft_range' object has no attribute 'nfta_data'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1548, in try_to_decode
    cell.decode()
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 2121, in decode
    nla_base.decode(self)
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1027, in decode
    cell.decode()
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 2121, in decode
    nla_base.decode(self)
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1031, in decode
    self.ft_decode(offset)
  File "/path/to/pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1442, in ft_decode
    raise NetlinkNLADecodeError(e)
pr2modules.netlink.exceptions.NetlinkNLADecodeError: 'nft_range' object has no attribute 'nfta_data'
```

This is fixed by 32163fd157c5c4d72bd8f952749d9a231f68cae1.

The other commit mainly fixes the name of the table property inside `nft_set_elem_list_msg`.