### PR TITLE
tc/em_ipset: fix a crash on encoding

### DIFF
--- a/pyroute2.core/pr2modules/netlink/rtnl/tcmsg/em_ipset.py
+++ b/pyroute2.core/pr2modules/netlink/rtnl/tcmsg/em_ipset.py
@@ -1,4 +1,5 @@
 from pr2modules.netlink import nlmsg_base
+from pr2modules.netlink import nlmsg_encoder_generic
 
 # see em_ipset.c
 IPSET_DIM = {
@@ -30,7 +31,7 @@ def get_parameters(kwarg):
     return ret
 
 
-class data(nlmsg_base):
+class data(nlmsg_base, nlmsg_encoder_generic):
     fields = (
         ('ip_set_index', 'H'),
         ('ip_set_dim', 'B'),


### PR DESCRIPTION
I found a new regression on master. Reproducer code is:

```python
from pyroute2 import IPRoute
from pyroute2.wiset import WiSet, load_ipset

with WiSet(name="toto-temporary") as wiset:
    wiset.create()
ip = IPRoute()
match = [{"kind": "ipset", "index": load_ipset("toto-temporary").index, "mode": "src"}]
ip.tc("add-filter", "basic", 0, parent=0x10000, classid=0x10010, match=match)

with WiSet(name="toto-temporary") as wiset:
    wiset.destroy()
```

On master, I get this backtrace:

```
  File "/bisect", line 8, in <module>
    ip.tc("add-filter", "basic", 0, parent=0x10000, classid=0x10010, match=match)
  File "pyroute2_pkg/pr2modules/iproute/linux.py", line 1725, in tc
    opts = p.get_parameters(kwarg)
  File "pyroute2_pkg/pr2modules/netlink/rtnl/tcmsg/cls_basic.py", line 170, in get_parameters
    ret['attrs'].append(['TCA_BASIC_EMATCHES', get_tcf_ematches(kwarg)])
  File "pyroute2_pkg/pr2modules/netlink/rtnl/tcmsg/common_ematch.py", line 90, in get_tcf_ematches
    data.encode()
  File "pyroute2_pkg/pr2modules/netlink/rtnl/tcmsg/em_ipset.py", line 46, in encode
    nlmsg_base.encode(self)
  File "pyroute2_pkg/pr2modules/netlink/__init__.py", line 1079, in encode
    offset, diff = self.ft_encode(offset)
AttributeError: 'data' object has no attribute 'ft_encode'
```

On "old" pyroute2 version the reproduced probably return a "no such devices" since indexes are not matching.

I bisected the regression to b74c231500e59dc6b2faaca676b4d20b79790305,
"netlink: nlmsg_encoder_generic".

Moving class "data" to ```nlmsg``` instead of ```nlmsg_base```
introduces another issue, with kernel returning EINVAL.
Only working solution I found was to inherit from nlmsg_encoder_generic