### PR TITLE
iproute: Support flags that do not fit into ifaddrmsg

### DIFF
--- a/pyroute2.core/pr2modules/iproute/linux.py
+++ b/pyroute2.core/pr2modules/iproute/linux.py
@@ -1543,7 +1543,8 @@ class RTNL_API(object):
         msg_type, msg_flags = get_msg_type(command, command_map)
 
         for field in msg.fields:
-            msg[field[0]] = request.pop(field[0], 0)
+            if field[0] != 'flags':  # Flags are supplied as NLA
+                msg[field[0]] = request.pop(field[0], 0)
 
         # work on NLA
         for key, value in request.items():


### PR DESCRIPTION
9a891ca02367ad8c1fcb31349a97f32c3f24860b causes flags that do not fit into the `flags` field of `ifaddrmsg` to raise an exception. Therefore, this commit always uses an `IFA_FLAGS` NLA to pass the flags.

```
# IFA_F_NOPREFIXROUTE is 0x200
ip.addr('add', index=index, address=address, prefixlen=prefixlen, flags=IFA_F_NOPREFIXROUTE)

# Currently raising an exception:
# ...
#   File "pyroute2/pyroute2.core/pr2modules/netlink/__init__.py", line 1519, in ft_encode
#     struct.pack_into(efmt, self.data, offset, value)
# struct.error: ubyte format requires 0 <= number <= 255
```

iproute2 handles this [similarly](https://github.com/shemminger/iproute2/blob/a17aac1b52d082fe8e4619603fe4022cf2eb9403/ip/ipaddress.c#L2485).