### PR TITLE
ci: restrict linter to the code runners

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   linter:
-    runs-on: Linux
+    runs-on: code
     steps:
       - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v3


### PR DESCRIPTION
Don't run linter on the ubuntu runner, some obscure git
related error prevents pre-commit from running there.