### PR TITLE
generic: add support for dumping policy

### DIFF
--- a/examples/policy/policy.py
+++ b/examples/policy/policy.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import traceback
+from pprint import pprint
+from pyroute2.netlink.generic import GenericNetlinkSocket
+
+if __name__ == '__main__':
+    try:
+        # create protocol instance
+        genl = GenericNetlinkSocket(ext_ack=True)
+
+        # extract policy
+        msg = genl.policy('nlctrl')
+
+        # dump policy information
+        pprint(msg)
+    except:
+        # if there was an error, log it to the console
+        traceback.print_exc()
+    finally:
+        # finally -- release the instance
+        genl.close()

--- a/pyroute2/netlink/generic/__init__.py
+++ b/pyroute2/netlink/generic/__init__.py
@@ -10,10 +10,13 @@ import logging
 
 from pyroute2.netlink import (
     CTRL_CMD_GETFAMILY,
+    CTRL_CMD_GETPOLICY,
     GENL_ID_CTRL,
     NETLINK_ADD_MEMBERSHIP,
     NETLINK_DROP_MEMBERSHIP,
     NLM_F_REQUEST,
+    NLM_F_ACK,
+    NLM_F_DUMP,
     SOL_NETLINK,
     ctrlmsg,
 )
@@ -100,3 +103,16 @@ class GenericNetlinkSocket(NetlinkSocket):
                     logger(self.module_err_message)
             raise err
         return msg
+
+    def policy(self, proto):
+        '''
+        Extract policy information for a generic netlink protocol -- takes
+        a string as the only parameter, return protocol policy
+        '''
+        self.marshal.msg_map[GENL_ID_CTRL] = ctrlmsg
+        msg = ctrlmsg()
+        msg['cmd'] = CTRL_CMD_GETPOLICY
+        msg['attrs'].append(['CTRL_ATTR_FAMILY_NAME', proto])
+        return self.nlm_request(
+            msg, msg_type = GENL_ID_CTRL, msg_flags = NLM_F_REQUEST | NLM_F_DUMP | NLM_F_ACK
+        )


### PR DESCRIPTION
Add basic support for dumping the policy data that the kernel can report
via CTRL_CMD_GETPOLICY.

The current implementation for parsing the mappings is a bit awkward since
it relies on a list comprehension to fill in the nla_map used.

This is done because the kernel presents some of the sections with nested
NLA where the attribute number is actually an index or a command opcode,
rather than using an extra attribute. Ideally, the nla or nlmsg classes
would be expanded to support this kind of nested substructure.

Eventually we probably want to extract the policy data into more useful
structures. In particular, converting the command opcodes and attribute ids
into human readable names would be ideal.

Add a very basic example which simply dumps and prints the policy data for
the nlctrl netlink family.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>
