### PR TITLE
Add support for the SRv6 End.DT46 behavior

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -2123,6 +2123,23 @@ class RTNL_API:
                 },
             )
 
+        Create SEG6LOCAL tunnel End.DT46 action (kernel >= 5.14)::
+
+            # $ sudo modprobe vrf
+            # $ sudo sysctl -w net.vrf.strict_mode=1
+
+            ip.link('add',
+                    ifname='vrf-foo',
+                    kind='vrf',
+                    vrf_table=10)
+
+            ip.route('add',
+                     dst='2001:0:0:10::2/128',
+                     oif=idx,
+                     encap={'type': 'seg6local',
+                            'action': 'End.DT46',
+                            'vrf_table': 10})
+
         Create SEG6LOCAL tunnel End.B6 action (kernel >= 4.14)::
 
             ipr.route(

--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -576,6 +576,7 @@ class rtmsg_base(nlflags):
             SEG6_LOCAL_ACTION_END_AS = 13
             SEG6_LOCAL_ACTION_END_AM = 14
             SEG6_LOCAL_ACTION_END_BPF = 15
+            SEG6_LOCAL_ACTION_END_DT46 = 16
 
             actions = {
                 'End': SEG6_LOCAL_ACTION_END,
@@ -593,6 +594,7 @@ class rtmsg_base(nlflags):
                 'End.AS': SEG6_LOCAL_ACTION_END_AS,
                 'End.AM': SEG6_LOCAL_ACTION_END_AM,
                 'End.BPF': SEG6_LOCAL_ACTION_END_BPF,
+                'End.DT46': SEG6_LOCAL_ACTION_END_DT46,
             }
 
             def encode(self):

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -390,6 +390,10 @@ class RouteIPRouteFilter(IPRouteFilter):
              'vrf_table': 10}
 
             {'type': 'seg6local',
+             'action': 'End.DT46',
+             'vrf_table': 10}
+
+            {'type': 'seg6local',
              'action': 'End.B6',
              'table': '10'
              'srh': {'segs': '2000::5,2000::6'}}

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -224,6 +224,10 @@ class RouteIPRouteFilter(IPRouteFilter):
             #           'vrf_table': 10}
             #
             # 'encap': {'type': 'seg6local',
+            #           'action': 'End.DT46',
+            #           'vrf_table': 10}
+            #
+            # 'encap': {'type': 'seg6local',
             #           'action': 'End.DX6',
             #           'nh6': '2000::5'}
             #
@@ -442,6 +446,9 @@ class RouteIPRouteFilter(IPRouteFilter):
                 # Retrieve table
                 table = header['table']
             elif action == 'End.DT4':
+                # Retrieve vrf_table
+                vrf_table = header['vrf_table']
+            elif action == 'End.DT46':
                 # Retrieve vrf_table
                 vrf_table = header['vrf_table']
             elif action == 'End.B6':


### PR DESCRIPTION
This PR adds the support for the SRv6 End.DT46 behavior.

The SRv6 End.DT46 behavior is used to implement L3VPN use-cases in multi-tenants environments. It decapsulates the received packets and it performs IPv4 or IPv6 routing lookup in the routing table of the tenant.

The SRv6 End.DT46 behavior has been introduced in the Linux kernel in the commit [1] and it is available since kernel version 5.15.
The iproute2 suite has been extended as well for supporting the SRv6 End.DT46 behavior [2].


An example iproute2 command to instantiate an SRv6 End.DT46 behavior is the following:

`  $ ip -6 route add 2001:db8::1 encap seg6local action End.DT46 vrftable 100 dev vrf100.`

In the above command, the `vrftable` attribute indicates the routing table associated with the VRF device used by SRv6 End.DT46 for routing IP packets.


The only prerequisite to instantiate an End.DT46 behavior is enabling the VRF `strict_mode` sysctl parameter

` $ sysctl -wq net.vrf.strict_mode=1`


Hereafter, we provide an example of how to instantiate an SRv6 End.DT46 behavior with pyroute2.

First, a VRF needs to be created:

```
	ip.link('add',
	           ifname='vrf-foo',
	           kind='vrf',
	           vrf_table=100)
```

Then, the following command can be used to instantiate the behavior:

```
	ip.route('add',
	             dst='2001:db8::1/128',
	             oif=idx,
	             encap={'type': 'seg6local',
	                          action': 'End.DT46',
	                          'vrf_table': 100})
```


[1] https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=8b532109bf885b7b59b93487bc4672eb6d071b78
[2] https://www.spinics.net/lists/netdev/msg749223.html
