### PR TITLE
dhcp/__init__.py: fix bytes vs. str in literal

### DIFF
--- a/pyroute2/dhcp/__init__.py
+++ b/pyroute2/dhcp/__init__.py
@@ -195,7 +195,7 @@ class option(msg):
                 isinstance(value, basestring)
                 and self.policy['format'] == 'string'
             ):
-                value = value[: value.find('\x00')]
+                value = value[: value.find(b'\x00')]
             self.value = value
         else:
             # remember current offset as msg.decode() will advance it


### PR DESCRIPTION
Looks like this string literal didn't get changed over to be a byte string during the python3 transition.