### PR TITLE
install ss2 as module as well

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -103,6 +103,7 @@ pyroute2 =
     RemoteIPRoute = pyroute2.remote:RemoteIPRoute
     dhcp = pyroute2.dhcp
     arp = pyroute2.arp
+    ss2 = pyroute2.netlink.diag.ss2
 console_scripts =
     ss2 = pyroute2.netlink.diag.ss2:run [psutil]
     pyroute2-cli = pyroute2.ndb.cli:run


### PR DESCRIPTION
prometheus_ss_exporter depends on the logic also as module.

Installing it as cli and tool makes it accessible conventiently to both ways of consumption.