### PR TITLE
iproute: support altname in link_lookup

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -778,7 +778,7 @@ class RTNL_API:
         Please note, that link_lookup() returns list, not one
         value.
         '''
-        if set(kwarg) in ({'index'}, {'ifname'}, {'index', 'ifname'}):
+        if kwarg and set(kwarg) < {'index', 'ifname', 'altname'}:
             # shortcut for index and ifname
             try:
                 for link in self.link('get', **kwarg):

--- a/tests/test_linux/test_ipr/test_link.py
+++ b/tests/test_linux/test_ipr/test_link.py
@@ -22,6 +22,17 @@ def test_updown_link(context):
 
 @skip_if_not_supported
 @pytest.mark.parametrize('context', test_matrix, indirect=True)
+def test_link_altname_lookup(context):
+    altname = context.new_ifname
+    index, ifname = context.default_interface
+    context.ipr.link('property_add', index=index, altname=altname)
+    assert len(context.ipr.link('get', altname=altname)) == 1
+    assert context.ipr.link_lookup(ifname=ifname) == [index]
+    assert context.ipr.link_lookup(altname=altname) == [index]
+
+
+@skip_if_not_supported
+@pytest.mark.parametrize('context', test_matrix, indirect=True)
 def test_link_altname(context):
     altname1 = context.new_ifname
     altname2 = context.new_ifname


### PR DESCRIPTION
Bug-Url: https://github.com/svinota/pyroute2/issues/1065