### PR TITLE
Add support for CGROUP_ID to inet_diag_message and fix type for CLASS_ID

### DIFF
--- a/pyroute2/netlink/diag/__init__.py
+++ b/pyroute2/netlink/diag/__init__.py
@@ -141,8 +141,11 @@ class inet_diag_msg(inet_addr_codec):
         ('INET_DIAG_PAD', 'hex'),
         ('INET_DIAG_MARK', 'hex'),
         ('INET_DIAG_BBRINFO', 'tcp_bbr_info'),
-        ('INET_DIAG_CLASS_ID', 'hex'),
+        ('INET_DIAG_CLASS_ID', 'uint32'),
         ('INET_DIAG_MD5SIG', 'hex'),
+        ('INET_DIAG_ULP_INFO', 'hex'),
+        ('INET_DIAG_SK_BPF_STORAGES', 'hex'),
+        ('INET_DIAG_CGROUP_ID', 'uint64'),
     )
 
     class inet_diag_meminfo(nla):


### PR DESCRIPTION
I currently use `inet_diag_msg` to look up the class id of sockets from the application's net_cls cgroup and I've been decoding the hex string, but always meant to make a PR to fix it to be uint32. I'm now upgrading the system to cgroup v2, so I need to move to cgroup id instead which required adding additional fields.

You can see where these are set upstream in the kernel here: https://github.com/torvalds/linux/blob/ac9a78681b921877518763ba0e89202254349d1b/net/ipv4/inet_diag.c#L170-L177
These fields are populated when you request the TCLASS extension.