### PR TITLE
do not import unittest if mock is disabled

### DIFF
--- a/pyroute2/lab.py
+++ b/pyroute2/lab.py
@@ -1,6 +1,3 @@
-import inspect
-from unittest import mock
-
 registry = []
 use_mock = False
 
@@ -9,6 +6,8 @@ class LAB_API:
     def __init__(self, *argv, **kwarg):
         super().__init__(*argv, **kwarg)
         if use_mock:
+            import inspect
+            from unittest import mock
             registry.append(self)
             for name, method in inspect.getmembers(
                 self, predicate=inspect.ismethod


### PR DESCRIPTION
I am working on an embedded Linux, whose python does not have unittest module supplied, 
I moved the import statements, if use_mock is True, then do import