### PR TITLE
sched_netem: fix duplicate attribute value for netem qdisc

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/sched_netem.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_netem.py
@@ -10,7 +10,7 @@ def get_parameters(kwarg):
     limit = kwarg.get('limit', 1000)  # fifo limit (packets) see netem.c:230
     loss = percent2u32(kwarg.get('loss', 0))  # int percentage
     gap = kwarg.get('gap', 0)
-    duplicate = kwarg.get('duplicate', 0)
+    duplicate = percent2u32(kwarg.get('duplicate', 0))  # int percentage
     jitter = time2tick(kwarg.get('jitter', 0))  # in microsecond
 
     opts = {


### PR DESCRIPTION
Just like the loss option, the duplicate option is given as a percentage so we should convert that percentage to a value in before using it.