### PR TITLE
lab: postpone unittest import error

### DIFF
--- a/pyroute2/lab.py
+++ b/pyroute2/lab.py
@@ -1,5 +1,9 @@
 import inspect
-from unittest import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 registry = []
 use_mock = False
@@ -9,6 +13,16 @@ class LAB_API:
     def __init__(self, *argv, **kwarg):
         super().__init__(*argv, **kwarg)
         if use_mock:
+            if mock is None:
+                # postpone ImportError
+                #
+                # unittest may not be available on embedded platforms,
+                # but it is still used by IPRoute class; it is safe
+                # to leave it in the minimal for now, just raise an
+                # exception when being used
+                #
+                # Bug-Url: https://github.com/svinota/pyroute2/pull/1096
+                raise ImportError('unittest.mock not available')
             registry.append(self)
             for name, method in inspect.getmembers(
                 self, predicate=inspect.ismethod


### PR DESCRIPTION
The issue is that unittest may not be provided on embedded platforms, though it is included in the minimal build. This is a workaround, a proper fix should exclude lab module from the minimal build.

Bug-Url: https://github.com/svinota/pyroute2/pull/1096