### PR TITLE
Allow passing args up to GenericNetlinkSocket constructor

### DIFF
--- a/pyroute2/netlink/devlink/__init__.py
+++ b/pyroute2/netlink/devlink/__init__.py
@@ -492,8 +492,8 @@ class MarshalDevlink(Marshal):
 
 
 class DevlinkSocket(GenericNetlinkSocket):
-    def __init__(self):
-        GenericNetlinkSocket.__init__(self)
+    def __init__(self, *args, **kwargs):
+        GenericNetlinkSocket.__init__(self, *args, **kwargs)
         self.marshal = MarshalDevlink()
 
     def bind(self, groups=0, **kwarg):

--- a/pyroute2/netlink/event/__init__.py
+++ b/pyroute2/netlink/event/__init__.py
@@ -6,8 +6,8 @@ class EventSocket(GenericNetlinkSocket):
     marshal_class = None
     genl_family = None
 
-    def __init__(self):
-        GenericNetlinkSocket.__init__(self)
+    def __init__(self, *args, **kwargs):
+        GenericNetlinkSocket.__init__(self, *args, **kwargs)
         self.marshal = self.marshal_class()
         if kernel[0] <= 2:
             self.bind(groups=0xFFFFFF)

--- a/pyroute2/netlink/generic/l2tp.py
+++ b/pyroute2/netlink/generic/l2tp.py
@@ -145,8 +145,8 @@ class l2tpmsg(genlmsg):
 
 
 class L2tp(GenericNetlinkSocket):
-    def __init__(self):
-        GenericNetlinkSocket.__init__(self)
+    def __init__(self, *args, **kwargs):
+        GenericNetlinkSocket.__init__(self, *args, **kwargs)
         self.bind(L2TP_GENL_NAME, l2tpmsg)
 
     def _do_request(self, msg, msg_flags=NLM_F_REQUEST | NLM_F_ACK):

--- a/pyroute2/netlink/generic/wireguard.py
+++ b/pyroute2/netlink/generic/wireguard.py
@@ -263,8 +263,8 @@ class wgmsg(genlmsg):
 
 
 class WireGuard(GenericNetlinkSocket):
-    def __init__(self):
-        GenericNetlinkSocket.__init__(self)
+    def __init__(self, *args, **kwargs):
+        GenericNetlinkSocket.__init__(self, *args, **kwargs)
         self.bind(WG_GENL_NAME, wgmsg)
 
     def info(self, interface):

--- a/pyroute2/netlink/nl80211/__init__.py
+++ b/pyroute2/netlink/nl80211/__init__.py
@@ -1533,8 +1533,8 @@ class MarshalNl80211(Marshal):
 
 
 class NL80211(GenericNetlinkSocket):
-    def __init__(self):
-        GenericNetlinkSocket.__init__(self)
+    def __init__(self, *args, **kwargs):
+        GenericNetlinkSocket.__init__(self, *args, **kwargs)
         self.marshal = MarshalNl80211()
 
     def bind(self, groups=0, **kwarg):

--- a/pyroute2/netlink/taskstats/__init__.py
+++ b/pyroute2/netlink/taskstats/__init__.py
@@ -119,9 +119,6 @@ class taskstatsmsg(genlmsg):
 
 
 class TaskStats(GenericNetlinkSocket):
-    def __init__(self):
-        GenericNetlinkSocket.__init__(self)
-
     def bind(self):
         GenericNetlinkSocket.bind(self, 'TASKSTATS', taskstatsmsg)
 


### PR DESCRIPTION
Currently, most subclasses of GenericNetlinkSocket do not pass unused args up to GenericNetlinkSocket.__init__.

One use case of this is to pass fileno= with an existing file descriptor that was opened in another process/network namespace.

This patch fixes the following subclasses

  - EventSocket
  - NL80211
  - DevlinkSocket
  - L2tp
  - WireGuard

by passing up *args and **kwargs.

We also fix TaskStats by simply removing the __init__ method that just calls super.

We did not need to fix MPTCP and NlEthtool as they don't overwrite __init__.