### PR TITLE
iproute: add support for netns nsid allocation

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -7,6 +7,7 @@ from functools import partial
 from itertools import chain
 from socket import AF_INET, AF_INET6, AF_UNSPEC
 
+import pyroute2.netns
 from pyroute2 import config
 from pyroute2.common import AF_MPLS, basestring
 from pyroute2.config import AF_BRIDGE
@@ -55,6 +56,7 @@ from pyroute2.netlink.rtnl import (
     RTM_NEWLINKPROP,
     RTM_NEWNEIGH,
     RTM_NEWNETNS,
+    RTM_NEWNSID,
     RTM_NEWQDISC,
     RTM_NEWROUTE,
     RTM_NEWRULE,
@@ -740,6 +742,34 @@ class RTNL_API:
                     yield item
             except OSError:
                 pass
+
+    def set_netnsid(self, name=None, fd=None, nsid=None):
+        '''Assigns an id to a peer netns using RTM_NEWNSID query.
+        The kernel chooses an unique id if nsid is omitted.
+        This corresponds to the "ip netns set" command.
+        '''
+        msg = nsidmsg()
+        fh = None
+
+        try:
+            if name is not None:
+                netns_path = pyroute2.netns._get_netnspath(name)
+                fh = open(netns_path, 'r')
+                fd = fh.fileno()
+
+            msg['attrs'].append(('NETNSA_FD', fd))
+            if nsid is None or nsid < 0:
+                # kernel auto select
+                msg['attrs'].append(('NETNSA_NSID', 4294967295))
+            else:
+                msg['attrs'].append(('NETNSA_NSID', nsid))
+
+            return self.nlm_request(
+                msg, RTM_NEWNSID, NLM_F_REQUEST | NLM_F_ACK
+            )
+        finally:
+            if fh is not None:
+                fh.close()
 
     # 8<---------------------------------------------------------------
 


### PR DESCRIPTION
I need to assign a nsid to peer netns and it looks like that pyroute2 is currently missing a `RTM_NEWNSID` (`ip netns set`) implementation. However, I am not sure if my approach for adding this request is good.