### PR TITLE
Fix "failed to open netns" error in RISCV64.

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -109,6 +109,7 @@ __NR = {
     'ppc6': {'64bit': 350},
     's390': {'64bit': 339},
     'loongarch64': {'64bit': 268},
+    'risc': {'64bit': 268},
 }
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 


### PR DESCRIPTION
The method bellow can be used to verify the modification in riscv64.
1. Create a test.py file with the following content. 
```
from pyroute2 import IPDB, NetNS
with IPDB(NetNS("test")) as ipdb_ns:
    print(ipdb_ns)
```
2. Run the following command to see if there exists any error. 
```
ip netns add test
python3 test.py
```