### PR TITLE
l2tp: Fix get_tunnel/get_session to return only requested object

### DIFF
--- a/pyroute2/netlink/generic/l2tp.py
+++ b/pyroute2/netlink/generic/l2tp.py
@@ -537,35 +537,50 @@ class L2tp(GenericNetlinkSocket):
 
         return self._do_request(msg)
 
-    def get_tunnel(self, tunnel_id=None):
+    def get_tunnel(self, tunnel_id):
         """
-        Get one or more tunnels
-        :param tunnel_id: tunnel id of the tunnel to show, if not set all
-                          tunnels will be returned
+        Get one tunnel
+        :param tunnel_id: tunnel id of the tunnel to show
         :return: netlink response
         """
         msg = l2tpmsg()
         msg["cmd"] = L2TP_CMD_TUNNEL_GET
         msg["version"] = L2TP_GENL_VERSION
-        if tunnel_id:
-            msg["attrs"].append(["L2TP_ATTR_CONN_ID", tunnel_id])
+        msg["attrs"].append(["L2TP_ATTR_CONN_ID", tunnel_id])
+        return self._do_request(msg, msg_flags=NLM_F_REQUEST)[0]
+
+    def dump_tunnels(self, tunnel_id):
+        """
+        Dump all tunnels
+        :return: netlink response
+        """
+        msg = l2tpmsg()
+        msg["cmd"] = L2TP_CMD_TUNNEL_GET
+        msg["version"] = L2TP_GENL_VERSION
         return self._do_request(msg, msg_flags=NLM_F_REQUEST | NLM_F_DUMP)
 
-    def get_session(self, tunnel_id=None, session_id=None):
+    def get_session(self, tunnel_id, session_id):
         """
-        Get one or more sessions
-        :param tunnel_id: tunnel id of the tunnel for which to show the
-                          session(s)
-        :param session_id: session id of the session to show, if not set all
-                           sessions will be returned
+        Get one session
+        :param tunnel_id: tunnel id of the session
+        :param session_id: session id of the session
         :return: netlink response
         """
         msg = l2tpmsg()
         msg["cmd"] = L2TP_CMD_SESSION_GET
         msg["version"] = L2TP_GENL_VERSION
-        if tunnel_id:
-            msg["attrs"].append(["L2TP_ATTR_CONN_ID", tunnel_id])
-        if session_id:
-            msg["attrs"].append(["L2TP_ATTR_SESSION_ID", session_id])
+        msg["attrs"].append(["L2TP_ATTR_CONN_ID", tunnel_id])
+        msg["attrs"].append(["L2TP_ATTR_SESSION_ID", session_id])
+
+        return self._do_request(msg, msg_flags=NLM_F_REQUEST)[0]
+
+    def dump_sessions(self):
+        """
+        Dump all sessions
+        :return: netlink response
+        """
+        msg = l2tpmsg()
+        msg["cmd"] = L2TP_CMD_SESSION_GET
+        msg["version"] = L2TP_GENL_VERSION
 
         return self._do_request(msg, msg_flags=NLM_F_REQUEST | NLM_F_DUMP)

--- a/tests/test_linux/test_generic/test_l2tp.py
+++ b/tests/test_linux/test_generic/test_l2tp.py
@@ -51,14 +51,14 @@ def test_complete(l2ctx):
         encap="udp",
     )
     tunnel = l2ctx.l2tp.get_tunnel(tunnel_id=2324)
-    assert tunnel[0].get_attr("L2TP_ATTR_CONN_ID") == 2324
-    assert tunnel[0].get_attr("L2TP_ATTR_PEER_CONN_ID") == 2425
-    assert tunnel[0].get_attr("L2TP_ATTR_IP_DADDR") == l2ctx.remote_ip
-    assert tunnel[0].get_attr("L2TP_ATTR_IP_SADDR") == l2ctx.local_ip
-    assert tunnel[0].get_attr("L2TP_ATTR_UDP_DPORT") == 32000
-    assert tunnel[0].get_attr("L2TP_ATTR_UDP_SPORT") == 32000
-    assert tunnel[0].get_attr("L2TP_ATTR_ENCAP_TYPE") == 0  # 0 == UDP
-    assert tunnel[0].get_attr("L2TP_ATTR_DEBUG") == 0
+    assert tunnel.get_attr("L2TP_ATTR_CONN_ID") == 2324
+    assert tunnel.get_attr("L2TP_ATTR_PEER_CONN_ID") == 2425
+    assert tunnel.get_attr("L2TP_ATTR_IP_DADDR") == l2ctx.remote_ip
+    assert tunnel.get_attr("L2TP_ATTR_IP_SADDR") == l2ctx.local_ip
+    assert tunnel.get_attr("L2TP_ATTR_UDP_DPORT") == 32000
+    assert tunnel.get_attr("L2TP_ATTR_UDP_SPORT") == 32000
+    assert tunnel.get_attr("L2TP_ATTR_ENCAP_TYPE") == 0  # 0 == UDP
+    assert tunnel.get_attr("L2TP_ATTR_DEBUG") == 0
 
     # 2. create session
     l2ctx.l2tp.create_session(
@@ -68,9 +68,9 @@ def test_complete(l2ctx):
         ifname=l2ctx.l2tpeth0,
     )
     session = l2ctx.l2tp.get_session(tunnel_id=2324, session_id=3435)
-    assert session[0].get_attr("L2TP_ATTR_SESSION_ID") == 3435
-    assert session[0].get_attr("L2TP_ATTR_PEER_SESSION_ID") == 3536
-    assert session[0].get_attr("L2TP_ATTR_DEBUG") == 0
+    assert session.get_attr("L2TP_ATTR_SESSION_ID") == 3435
+    assert session.get_attr("L2TP_ATTR_PEER_SESSION_ID") == 3536
+    assert session.get_attr("L2TP_ATTR_DEBUG") == 0
 
     # setting up DEBUG -> 95, operation not supported; review the test
     # # 3. modify session
@@ -88,8 +88,8 @@ def test_complete(l2ctx):
     l2ctx.l2tp.delete_session(tunnel_id=2324, session_id=3435)
     for _ in range(5):
         try:
-            assert not l2ctx.l2tp.get_session(tunnel_id=2324, session_id=3435)
-        except AssertionError:
+            l2ctx.l2tp.get_session(tunnel_id=2324, session_id=3435)
+        except NetlinkError:
             time.sleep(0.1)
             continue
         break
@@ -100,8 +100,8 @@ def test_complete(l2ctx):
     l2ctx.l2tp.delete_tunnel(tunnel_id=2324)
     for _ in range(5):
         try:
-            assert not l2ctx.l2tp.get_tunnel(tunnel_id=2324)
-        except AssertionError:
+            l2ctx.l2tp.get_tunnel(tunnel_id=2324)
+        except NetlinkError:
             time.sleep(0.1)
             continue
         break


### PR DESCRIPTION
L2TP does not support using filters on NLM_F_DUMP and always returns all objects. The current get_tunnel/session functions however always use NLM_F_DUMP and set the tunnel/session ids if provided by the caller. These are simply ignored.

This patch fixes get_tunnel and get_session to always require specifying the desired tunnel/session id to always get one requested object. If the requested object does not exist an NetlinkError is thrown.

To also provide a way to get all tunnels/sessions dump_tunnels and dump_sessions has been introduced.

---

Note that does does change the signature of `get_tunnel` and `get_session`. I've also adjusted the return value to return the one `l2tpmsg` message we get, so users don't need a odd `[0]` anymore. 