### PR TITLE
Makefile: use nox as a Python module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 python ?= $(shell util/find_python.sh)
 
 define nox
-	nox $(1) -- '$(subst ",\",${noxconfig})'
+	python3 -m nox $(1) -- '$(subst ",\",${noxconfig})'
 endef
 
 .PHONY: all


### PR DESCRIPTION
Debian packages don't provide `nox` file. Hence, use it as a module.