### PR TITLE
Fix NDB Source object's counting and update documentation

### DIFF
--- a/pyroute2/ndb/source.py
+++ b/pyroute2/ndb/source.py
@@ -180,6 +180,12 @@ class Source(dict):
         self.ndb.task_manager.db_add_nl_source(self.target, self.kind, spec)
         self.load_sql()
 
+    @classmethod
+    def _count(cls, view):
+        return view.ndb.task_manager.db_fetchone(
+            "SELECT count(*) FROM %s" % view.table
+        )
+
     @property
     def must_restart(self):
         if self.max_errors < 0 or self.errors_counter <= self.max_errors:

--- a/pyroute2/ndb/source.py
+++ b/pyroute2/ndb/source.py
@@ -7,10 +7,21 @@ Local RTNL source is a simple `IPRoute` instance. By default NDB
 starts with one local RTNL source names `localhost`::
 
     >>> ndb = NDB()
-    >>> ndb.sources.details()
-    {'kind': u'local', u'nlm_generator': 1, 'target': u'localhost'}
+    >>> ndb.sources.summary().format("json")
+    [
+        {
+            "name": "localhost",
+            "spec": "{'target': 'localhost', 'nlm_generator': 1}",
+            "state": "running"
+        },
+        {
+            "name": "localhost/nsmanager",
+            "spec": "{'target': 'localhost/nsmanager'}",
+            "state": "running"
+        }
+    ]
     >>> ndb.sources['localhost']
-    [running] <IPRoute {'nlm_generator': 1}>
+    [running] <IPRoute {'target: 'localhost', 'nlm_generator': 1}>
 
 The `localhost` RTNL source starts an additional async cache thread.
 The `nlm_generator` option means that instead of collections the
@@ -18,7 +29,7 @@ The `nlm_generator` option means that instead of collections the
 consume memory regardless of the RTNL objects number::
 
     >>> ndb.sources['localhost'].nl.link('dump')
-    <generator object _match at 0x7fa444961e10>
+    <generator object RTNL_API.filter_messages at 0x7f61a99a34a0>
 
 See also: :ref:`iproute`
 

--- a/tests/test_linux/test_ndb/test_sources.py
+++ b/tests/test_linux/test_ndb/test_sources.py
@@ -38,6 +38,7 @@ def test_multiple_sources(context):
         assert len(list(ndb.neighbours.dump()))
         assert len(list(ndb.addresses.dump()))
         assert len(list(ndb.routes.dump()))
+        assert len(ndb.sources) == len(sources)
     # here NDB() gets closed
     #
 


### PR DESCRIPTION
The following code snippet gives me an error, but with other objects that works fine.
```python
>>> from pyroute2 import NDB

>>> ndb = NDB()
>>> ndb.sources
AttributeError: type object 'Source' has no attribute '_count'
list(ndb.sources)
AttributeError: type object 'Source' has no attribute '_count'
```

With this patchset applied I got the following output:
```python
>>> ndb.sources


NDB view for sources
Number of objects: 2

to list objects use .summary() or .dump()
    -> RecordSet (generator)
        -> Record

key: Union[Record, dict, spec]
to get objects use ...[key] / .__getitem__(key)
    -> RTNL_Object

>>> list(ndb.sources)
['localhost', 'localhost/nsmanager']
```
The reason behind the absence of this method is that `Source` subclasses `dict`, and there is no real interface in terms of typing that is common to `Source` and other NDB objects (which subclass `RTNL_object`). Therefore, with this PR, I am addressing only the consequence, not the root cause.

Also sources documentation has usage of an inexistent method `.details()`, so I gave some love to the docs too.
The the one thing I'm not sure, is the following statement:
> By default NDB starts with one local RTNL source names `localhost`

It seems I have 2 sources on my pretty default setup. So waiting for your guidance here :)