### PR TITLE
ndb: make non-unique FDB index more unique

### DIFF
--- a/pyroute2/ndb/objects/neighbour.py
+++ b/pyroute2/ndb/objects/neighbour.py
@@ -48,8 +48,9 @@ ndmsg_schema = (
 
 brmsg_schema = (
     ndmsg.sql_schema()
-    .unique_index('ifindex', 'NDA_LLADDR', 'NDA_VLAN')
+    .unique_index('ifindex', 'NDA_LLADDR', 'NDA_DST', 'NDA_VLAN')
     .constraint('NDA_LLADDR', "NOT NULL DEFAULT ''")
+    .constraint('NDA_DST', "NOT NULL DEFAULT ''")
     .constraint('NDA_VLAN', "NOT NULL DEFAULT 0")
     .foreign_key(
         'interfaces',


### PR DESCRIPTION
I found out that brmsg_schema has unique index on (ifindex, lladdr, vlan), so that gives an answer to me what happend in the linked issue.

There can be multicast FDBs with single ifindex and no NDA_VLAN at all (that means NDA_VLAN = 0), but NDA_DST will be different.

We can clearly see that in the example from the issue:
```
~# bridge fdb show | grep 00:00:00:00:00:00
00:00:00:00:00:00 dev vxln7 dst 10.1.0.107 self extern_learn permanent
00:00:00:00:00:00 dev vxln7 dst 10.1.0.11 self extern_learn permanent
```

This change of index breaks backward compatibility for filters like this:
```python
fdb = ndb.fdb.dump()
fdb.select_records(dst=lambda dst: dst is not None)
do_something_with(list(fdb))
```
Now it's more like identity check:
```python
fdb.select_records(dst=lambda dst: dst)
```

*Closes:* #1091 