### PR TITLE
NDB: Route Replace Error

### DIFF
--- a/pyroute2/ndb/schema.py
+++ b/pyroute2/ndb/schema.py
@@ -127,6 +127,7 @@ from collections import OrderedDict
 from functools import partial
 
 from pyroute2 import config
+from pyroute2.netlink import NLM_F_REPLACE
 from pyroute2.common import basestring, uuid32
 
 #
@@ -904,6 +905,26 @@ class DBSchema:
             compiled = self.compiled[table]
             # a map of sub-NLAs
             nodes = {}
+            # replace
+            r_conditions = []
+            r_values = []
+
+            # Check route replace
+            if event['header'].get('flags', 0) == NLM_F_REPLACE and event['event'] == 'RTM_NEWROUTE':
+                # Replace existing route
+                r_conditions = [table + '.f_target = %s' % self.plch]
+                r_values = [target]
+                for key in self.indices[table]:
+                    if key not in ['RTA_DST', 'dst_len', 'table', 'RTA_PRIORITY']:
+                        continue
+
+                    r_conditions.append(table + '.f_%s = %s' % (key, self.plch))
+                    value = event.get(key) or event.get_attr(key)
+                    if value is None:
+                        value = self.key_defaults[table][key]
+                    if isinstance(value, (dict, list, tuple, set)):
+                        value = json.dumps(value)
+                    r_values.append(value)
 
             # fetch values (exc. the first two columns)
             for fname, ftype in self.spec[table].items():
@@ -940,6 +961,12 @@ class DBSchema:
                 values.append(value)
 
             try:
+                w_fidx = compiled['fidx']
+                w_ivalues = ivalues
+                if r_conditions:
+                    w_fidx = ' AND '.join(r_conditions)
+                    w_ivalues = r_values
+
                 if self.provider == DBProvider.psycopg2:
                     #
                     # run UPSERT -- the DB provider must support it
@@ -955,9 +982,9 @@ class DBSchema:
                                 compiled['plchs'],
                                 compiled['knames'],
                                 compiled['fset'],
-                                compiled['fidx'],
+                                w_fidx,
                             ),
-                            (values + values + ivalues),
+                            (values + values + w_ivalues),
                         )
                     )
                     #
@@ -974,8 +1001,8 @@ class DBSchema:
                             '''
                                       SELECT count(*) FROM %s WHERE %s
                                       '''
-                            % (table, compiled['fidx']),
-                            ivalues,
+                            % (table, w_fidx),
+                            w_ivalues,
                         ).fetchone()
                     )[0]
                     if count == 0:
@@ -991,8 +1018,8 @@ class DBSchema:
                             '''
                                      UPDATE %s SET %s WHERE %s
                                      '''
-                            % (table, compiled['fset'], compiled['fidx']),
-                            (values + ivalues),
+                            % (table, compiled['fset'], w_fidx),
+                            (values + w_ivalues),
                         )
                 else:
                     raise NotImplementedError()


### PR DESCRIPTION
When modifying an existing route with a different
Gateway and Interface the current code does not query the existing route correctly from the database.
Hence we end up with 2 routes in the database instead of replaceing the existing one.

We need to specifically limit the count query to the unique attributes of a route that is replaced which are DST, DST_LEN, Priority and Table.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>