### PR TITLE
connector.cn_proc: support kwargs for bind

### DIFF
--- a/pyroute2/netlink/connector/cn_proc.py
+++ b/pyroute2/netlink/connector/cn_proc.py
@@ -147,8 +147,8 @@ class ProcEventSocket(ConnectorSocket):
         super().__init__(fileno=fileno)
         self.marshal = ProcEventMarshal()
 
-    def bind(self):
-        return super().bind(groups=CN_IDX_PROC)
+    def bind(self, **kwarg):
+        return super().bind(groups=CN_IDX_PROC, **kwarg)
 
     def control(self, listen):
         msg = proc_event_control()


### PR DESCRIPTION
This is useful to be able to set e.g. `async_cache` without needing to manually call `ConnectorSocket.bind`.