### PR TITLE
ndb: fix FDB non-uniquness on different FLAGS

### DIFF
--- a/pyroute2/ndb/objects/neighbour.py
+++ b/pyroute2/ndb/objects/neighbour.py
@@ -48,7 +48,7 @@ ndmsg_schema = (
 
 brmsg_schema = (
     ndmsg.sql_schema()
-    .unique_index('ifindex', 'NDA_LLADDR', 'NDA_DST', 'NDA_VLAN')
+    .unique_index('ifindex', 'NDA_LLADDR', 'NDA_DST', 'NDA_VLAN', 'flags')
     .constraint('NDA_LLADDR', "NOT NULL DEFAULT ''")
     .constraint('NDA_DST', "NOT NULL DEFAULT ''")
     .constraint('NDA_VLAN', "NOT NULL DEFAULT 0")


### PR DESCRIPTION
**Closes**: #1159

I didn't read logs carefully, unfortunately :)

Every time we got FDB missing we got the following 3 reschedules followed by drop as well:
```
2024-06-27 10:30:36,747    DEBUG pyroute2.ndb.139893147176048.main: reschedule {'family': 7, '__pad': (), 'ifindex': 28, 'state': 128, 'flags': 2, 'ndm_type': 0, 'attrs': [('NDA_LLADDR', '1c:34:da:3c:71:2c'), ('NDA_IFINDEX', 28), ('NDA_DST', ''), ('NDA_VLAN', 0)], 'header': {'length': 40, 'type': 28, 'flags': 2, 'sequence_number': 257, 'pid': 4060981674, 'error': None, 'target': 'localhost', 'stats': Stats(qsize=0, delta=0, delay=0), 'rcounter': 1}, 'event': 'RTM_NEWNEIGH'}
2024-06-27 10:30:37,040    DEBUG pyroute2.ndb.139893147176048.main: reschedule {'family': 7, '__pad': (), 'ifindex': 28, 'state': 128, 'flags': 2, 'ndm_type': 0, 'attrs': [('NDA_LLADDR', '1c:34:da:3c:71:2c'), ('NDA_IFINDEX', 28), ('NDA_DST', ''), ('NDA_VLAN', 0)], 'header': {'length': 40, 'type': 28, 'flags': 2, 'sequence_number': 257, 'pid': 4060981674, 'error': None, 'target': 'localhost', 'stats': Stats(qsize=0, delta=0, delay=0), 'rcounter': 2}, 'event': 'RTM_NEWNEIGH'}
2024-06-27 10:30:37,079    DEBUG pyroute2.ndb.139893147176048.main: reschedule {'family': 7, '__pad': (), 'ifindex': 28, 'state': 128, 'flags': 2, 'ndm_type': 0, 'attrs': [('NDA_LLADDR', '1c:34:da:3c:71:2c'), ('NDA_IFINDEX', 28), ('NDA_DST', ''), ('NDA_VLAN', 0)], 'header': {'length': 40, 'type': 28, 'flags': 2, 'sequence_number': 257, 'pid': 4060981674, 'error': None, 'target': 'localhost', 'stats': Stats(qsize=0, delta=0, delay=0), 'rcounter': 3}, 'event': 'RTM_NEWNEIGH'}
2024-06-27 10:30:37,084    ERROR pyroute2.ndb.139893147176048.main: drop {'family': 7, '__pad': (), 'ifindex': 28, 'state': 128, 'flags': 2, 'ndm_type': 0, 'attrs': [('NDA_LLADDR', '1c:34:da:3c:71:2c'), ('NDA_IFINDEX', 28), ('NDA_DST', ''), ('NDA_VLAN', 0)], 'header': {'length': 40, 'type': 28, 'flags': 2, 'sequence_number': 257, 'pid': 4060981674, 'error': None, 'target': 'localhost', 'stats': Stats(qsize=0, delta=0, delay=0), 'rcounter': 3}, 'event': 'RTM_NEWNEIGH'}
```

After logging the error I understood that there were 2 FDBs very similar, only difference was flags and master:
```python
In [40]: ip.fdb('dump')
Out[40]:

(
    ...
    {
        'family': 7,
        '__pad': (),
        'ifindex': 28,
        'state': 128,
        'flags': 0,
        'ndm_type': 0,
        'attrs': [
            ('NDA_LLADDR', '1c:34:da:3c:71:2c'),
            ('NDA_MASTER', 39),
            ('NDA_CACHEINFO', {'ndm_confirmed': 0, 'ndm_used': 3401745381, 'ndm_updated': 3401745381, 'ndm_refcnt': 0})
        ],
        'header': {
            'length': 68,
            'type': 28,
            'flags': 2,
            'sequence_number': 266,
            'pid': 3070174158,
            'error': None,
            'target': 'localhost',
            'stats': Stats(qsize=0, delta=0, delay=0)
        },
        'event': 'RTM_NEWNEIGH'
    },
    {
        'family': 7,
        '__pad': (),
        'ifindex': 28,
        'state': 128,
        'flags': 2,
        'ndm_type': 0,
        'attrs': [('NDA_LLADDR', '1c:34:da:3c:71:2c')],
        'header': {
            'length': 40,
            'type': 28,
            'flags': 2,
            'sequence_number': 266,
            'pid': 3070174158,
            'error': None,
            'target': 'localhost',
            'stats': Stats(qsize=0, delta=0, delay=0)
        },
        'event': 'RTM_NEWNEIGH'
    },
    ...
)
```

```python
In [34]: list(ndb.fdb.dump())
Out[34]:

[
    ...
    ('localhost', 0, 7, 28, 128, 0, 0, '', '1c:34:da:3c:71:2c', None, 0, None, None, 28, 39, None, None),
    ...
]
```

After making `flags` field a part of unique index that entry did showed up in the DB:
```python
In [1]: list(ndb.fdb.dump())
Out[1]:
[
    ...
    ('localhost', 0, 7, 28, 128, 0, 0, '', '1c:34:da:3c:71:2c', None, 0, None, None, 28, 39, None, None)
    ('localhost', 0, 7, 28, 128, 2, 0, '', '1c:34:da:3c:71:2c', None, 0, None, None, 28, None, None, None)
    ...
]
```