### PR TITLE
Fix TC Cake Plugin

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_cake.py
@@ -103,7 +103,7 @@ TCA_CAKE_MAX_TINS = 8
 
 
 def fix_msg(msg, kwarg):
-    if 'parent' not in kwarg:
+    if 'parent' not in msg or msg['parent'] == 0:
         msg['parent'] = TC_H_ROOT
 
 

--- a/tests/test_repo/test_version.py
+++ b/tests/test_repo/test_version.py
@@ -2,8 +2,7 @@ import io
 import re
 
 import pytest
-from setuptools._vendor import packaging
-
+from packaging.version import Version, InvalidVersion
 
 @pytest.fixture
 def files():
@@ -29,6 +28,11 @@ def test_changelog(files):
     for line in files['CHANGELOG.rst'].readlines():
         if line[0] == '*':
             break
-    static_version = packaging.version.parse(files['VERSION'].getvalue())
-    last_changelog_version = packaging.version.parse(line.split()[1])
+
+    try:
+        static_version = Version(files['VERSION'].getvalue().strip())
+        last_changelog_version = Version(line.split()[1])
+    except InvalidVersion as e:
+        pytest.fail(f"Invalid version encountered: {e}")
+
     assert static_version >= last_changelog_version


### PR DESCRIPTION
Hello pyroute2 team,

This PR was created to propose a solution to a behavior in the cake tc plugin wherein tc pops off the 'parent' key from kwarg and onto msg:

```
        if kind in tc_plugins:
            p = tc_plugins[kind]
            msg['parent'] = kwarg.pop('parent', getattr(p, 'parent', 0))
            if hasattr(p, 'fix_msg'):
                p.fix_msg(msg, kwarg)
            if kwarg:
                if command in (RTM_NEWTCLASS, RTM_DELTCLASS):
                    opts = p.get_class_parameters(kwarg)
                else:
                    opts = p.get_parameters(kwarg)
        else:
            msg['parent'] = kwarg.get('parent', TC_H_ROOT)
```
            
Then, when hasattr(p, 'fix_msg') is evaluated, the kind cake does have a p attribute, which cake does have, and it drops into fix_msg:

```
def fix_msg(msg, kwarg):
    if 'parent' not in kwarg:
        msg['parent'] = TC_H_ROOT
```
        
Which, because it just popped 'parent' from kwarg, it is always not present, causing msg['parent'] to be mangled by TC_H_ROOT. My proposed fix:
        

```
        def fix_msg(msg, kwarg):
           if 'parent' not in msg or msg['parent'] == 0:
              msg['parent'] = TC_H_ROOT
```
              
Checks msg, and if 'parent' is either not present or is 0, sets the value to TC_H_ROOT. Please let me know if this is in line with the general idea of fix_msg. In my testing this does allow cake qdiscs to be created under a defined parent class. 

Thank you.        
        