### PR TITLE
switch euid/ruid field names for uid/gid events

### DIFF
--- a/pyroute2/netlink/connector/cn_proc.py
+++ b/pyroute2/netlink/connector/cn_proc.py
@@ -59,7 +59,7 @@ class proc_event_uid(proc_event_base):
         ('process_pid', 'I'),
         ('process_tgid', 'I'),
         ('ruid', 'I'),
-        ('rgid', 'I'),
+        ('euid', 'I'),
     )
 
 
@@ -67,7 +67,7 @@ class proc_event_gid(proc_event_base):
     fields = proc_event_base.fields + (
         ('process_pid', 'I'),
         ('process_tgid', 'I'),
-        ('euid', 'I'),
+        ('rgid', 'I'),
         ('egid', 'I'),
     )
 


### PR DESCRIPTION
change `proc_event_uid` and `proc_event_gid` to return `ruid/euid` and `rgid/egid` respectively.   currently the values are using the union of each event type.

great feature by the way!