### PR TITLE
Adding kwarg parameter to ipmock

### DIFF
--- a/pyroute2/iproute/ipmock.py
+++ b/pyroute2/iproute/ipmock.py
@@ -679,13 +679,13 @@ class IPRoute(LAB_API, NetlinkSocketBase):
 
         return self._get_dump([route], rtmsg)
 
-    def get_addr(self):
+    def get_addr(self, **kwarg):
         return self._get_dump(self.preset['addr'], ifaddrmsg)
 
-    def get_links(self):
+    def get_links(self, **kwarg):
         return self._get_dump(self.preset['links'], ifinfmsg)
 
-    def get_routes(self):
+    def get_routes(self, **kwarg):
         return self._get_dump(self.preset['routes'], rtmsg)
 
 


### PR DESCRIPTION
Pylint is reporting a false positive unexpected-keyword-arg. At first I thought it was a pylint bug, so I reported it: https://github.com/pylint-dev/pylint/issues/9922. But as it turned out, the bug is in the ipmock module inside pyroute2. Some functions lack a **kwarg parameter, so it needs to be added there, that's why I created this PR.