### PR TITLE
fix state and noarp flag setting in LinkFieldFilter

### DIFF
--- a/pyroute2/requests/link.py
+++ b/pyroute2/requests/link.py
@@ -1,4 +1,4 @@
-from pyroute2.netlink.rtnl.ifinfmsg import IFF_NOARP, ifinfmsg
+from pyroute2.netlink.rtnl.ifinfmsg import IFF_UP, IFF_NOARP, ifinfmsg
 from pyroute2.netlink.rtnl.ifinfmsg.plugins.vlan import flags as vlan_flags
 
 from .common import Index, IPRouteFilter, NLAKeyTransform
@@ -75,22 +75,22 @@ class LinkIPRouteFilter(IPRouteFilter):
         if self.command == 'dump':
             return {'state': value}
         if value == 'up':
-            ret['flags'] = context.get('flags', 0) or 0 | 1
-        ret['change'] = context.get('change', 0) or 0 | 1
+            ret['flags'] = (context.get('flags', 0) or 0) | IFF_UP
+        ret['change'] = (context.get('change', 0) or 0) | IFF_UP
         return ret
 
     def set_arp(self, context, value):
         ret = {}
         if not value:
-            ret['flags'] = context.get('flags', 0) or 0 | IFF_NOARP
-        ret['change'] = context.get('change', 0) or 0 | IFF_NOARP
+            ret['flags'] = (context.get('flags', 0) or 0) | IFF_NOARP
+        ret['change'] = (context.get('change', 0) or 0) | IFF_NOARP
         return ret
 
     def set_noarp(self, context, value):
         ret = {}
         if value:
-            ret['flags'] = context.get('flags', 0) or 0 | IFF_NOARP
-        ret['change'] = context.get('change', 0) or 0 | IFF_NOARP
+            ret['flags'] = (context.get('flags', 0) or 0) | IFF_NOARP
+        ret['change'] = (context.get('change', 0) or 0) | IFF_NOARP
         return ret
 
     def finalize(self, context):

--- a/tests/test_unit/test_requests/test_link.py
+++ b/tests/test_unit/test_requests/test_link.py
@@ -2,6 +2,7 @@ import pytest
 from common import Request, Result, run_test
 
 from pyroute2.requests.link import LinkFieldFilter, LinkIPRouteFilter
+from pyroute2.netlink.rtnl.ifinfmsg import IFF_UP, IFF_NOARP
 
 config_add = {
     'filters': (
@@ -89,3 +90,35 @@ def test_index(config, spec, result):
 )
 def test_dump_specific(spec, result):
     return run_test(config_dump, spec, result)
+
+
+@pytest.mark.parametrize(
+    'spec,result',
+    (
+        (
+            Request({'kind': 'bridge', 'state': 'up'}),
+            Result(
+                {
+                    'flags': IFF_UP,
+                    'change': IFF_UP,
+                    'index': 0,
+                    'IFLA_LINKINFO': {'attrs': [['IFLA_INFO_KIND', 'bridge']]}
+                }
+            ),
+        ),
+        (
+            Request({'kind': 'bridge', 'state': 'up', 'noarp': True}),
+            Result(
+                {
+                    'flags': IFF_UP | IFF_NOARP,
+                    'change': IFF_UP | IFF_NOARP,
+                    'index': 0,
+                    'IFLA_LINKINFO': {'attrs': [['IFLA_INFO_KIND', 'bridge']]}
+                }
+            ),
+        ),
+    ),
+    ids=['flags1', 'flags2'],
+)
+def test_add_filter(spec, result):
+    return run_test(config_add, spec, result)


### PR DESCRIPTION
I submit this pull request which fixes setting the state and noarp flags in LinkFieldFilter. Previously, the flags were not combined together due probably due to an operator precedence oversight.

First, a commit introduces two tests:

- A trivial `state='up'` test which passes
- A combined `state='up'` and `noarp=True` test which fails due to LinkFieldFilter failing to combine the two flags

Then, a further commit fixes the underlying issue:
- Parenthesization fixes the operator precedence issue
- The hardcoded value `1` is replaced with constant `IFF_UP`