### PR TITLE
Draft: requests/tc: do not try to fix del requests

### DIFF
--- a/pyroute2/requests/tc.py
+++ b/pyroute2/requests/tc.py
@@ -39,6 +39,9 @@ class TcIPRouteFilter(IPRouteFilter):
         if 'handle' not in context:
             context['handle'] = 0
 
+        if self.command == "del-class":
+            return
+
         # get & run the plugin
         if 'kind' in context:
             if context['kind'] in tc_plugins:


### PR DESCRIPTION
Hello,

This is a proof of concept of a fixup for del-class command. It looks like "fix_request" and other magic for tc are breaking a simple command:

```python
ipr = IPRoute()
ipr.tc('del-class', 'htb', if_index, classid)
```

We do not need TCA_HTB_PARMS argument for this command (and perhaps some other? I did not check).