### PR TITLE
tc: fix get_qdiscs(index=...)

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -416,7 +416,7 @@ class RTNL_API:
 
         A compatibility method, == .tc("dump")
         '''
-        return await self.tc('dump')
+        return await self.tc('dump', index=index)
 
     async def get_filters(self, index=0, handle=0, parent=0):
         '''

--- a/tests/test_core/pr2test/tools.py
+++ b/tests/test_core/pr2test/tools.py
@@ -126,13 +126,15 @@ def filter_exists(
 
 
 def qdisc_exists(
-    ifname, handle, default=None, netns=None, timeout=1, retry=0.2
+    ifname, handle, default=None, rate=None, netns=None, timeout=1, retry=0.2
 ):
     filters = [ip_object_filter(query='.handle', value=handle)]
     if default is not None:
         filters.append(
             ip_object_filter(query='.options.default', value=default)
         )
+    if rate is not None:
+        filters.append(ip_object_filter(query='.options.rate', value=rate))
     return wait_for_ip_object(
         ['tc', '-json', 'qdisc', 'show', 'dev', ifname],
         filters,


### PR DESCRIPTION
The old version could filter qdiscs by the interface index, fix that in the new API.

Bug-Url: https://github.com/svinota/pyroute2/issues/1225