### PR TITLE
requests: fix rule (src|dst)(_len)

### DIFF
--- a/pyroute2/requests/rule.py
+++ b/pyroute2/requests/rule.py
@@ -37,7 +37,10 @@ class RuleIPRouteFilter(IPRouteFilter):
             if 'table' in context and 'action' not in context:
                 context['action'] = 'to_tbl'
             for key in ('src_len', 'dst_len'):
-                if context.get(key, None) is None and key[:3] in context:
+                if (
+                    context.get(key, None) is None
+                    and context.get(key[:3], None) is not None
+                ):
                     context[key] = {socket.AF_INET6: 128, socket.AF_INET: 32}[
                         context['family']
                     ]

--- a/tests/test_core/pr2test/tools.py
+++ b/tests/test_core/pr2test/tools.py
@@ -80,6 +80,14 @@ def route_exists(dst, table='main', netns=None, timeout=1, retry=0.2):
     )
 
 
+def rule_exists(priority, netns=None, timeout=1, retry=0.2):
+    ns = [] if netns is None else ['ip', 'netns', 'exec', netns]
+    filters = [ip_object_filter(query='.priority', value=priority)]
+    return wait_for_ip_object(
+        ns + ['ip', '-json', 'rule', 'show'], filters, timeout, retry
+    )
+
+
 def class_exists(
     ifname,
     handle,

--- a/tests/test_core/test_ipr/test_rule_async.py
+++ b/tests/test_core/test_ipr/test_rule_async.py
@@ -1,0 +1,24 @@
+import pytest
+from pr2test.tools import rule_exists
+
+
+@pytest.mark.parametrize(
+    'priority,spec',
+    [
+        (30313, {'table': 10}),
+        (30314, {'table': 10, 'src': None}),
+        (30315, {'table': 10, 'dst': None}),
+        (30316, {'table': 10, 'dst': '127.0.0.0/24'}),
+        (30317, {'table': 10, 'src': '127.0.0.0/24'}),
+    ],
+)
+@pytest.mark.parametrize(
+    'async_ipr',
+    [{'netns': True, 'ext_ack': True, 'strict_check': True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_rule_strict_src(async_ipr, priority, spec):
+    netns = async_ipr.status['netns']
+    await async_ipr.rule('add', priority=priority, **spec)
+    assert rule_exists(priority=priority, netns=netns)

--- a/tests/test_core/test_ipr/test_rule_sync.py
+++ b/tests/test_core/test_ipr/test_rule_sync.py
@@ -1,0 +1,23 @@
+import pytest
+from pr2test.tools import rule_exists
+
+
+@pytest.mark.parametrize(
+    'priority,spec',
+    [
+        (30313, {'table': 10}),
+        (30314, {'table': 10, 'src': None}),
+        (30315, {'table': 10, 'dst': None}),
+        (30316, {'table': 10, 'dst': '127.0.0.0/24'}),
+        (30317, {'table': 10, 'src': '127.0.0.0/24'}),
+    ],
+)
+@pytest.mark.parametrize(
+    'sync_ipr',
+    [{'netns': True, 'ext_ack': True, 'strict_check': True}],
+    indirect=True,
+)
+def test_rule_strict_src(sync_ipr, priority, spec):
+    netns = sync_ipr.status['netns']
+    sync_ipr.rule('add', priority=priority, **spec)
+    assert rule_exists(priority=priority, netns=netns)


### PR DESCRIPTION
Don't set src/dst len if src/dst absent or is None

Bug-Url: https://github.com/svinota/pyroute2/issues/1246