### PR TITLE
ifinfmsg: fix xdp flags

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
@@ -621,7 +621,7 @@ class ifinfbase(object):
             sql_type = None
 
         class xdp_flags(nla):
-            fields = [('value', '>H')]
+            fields = [('value', 'I')]
             sql_type = 'INTEGER'
 
             def encode(self):


### PR DESCRIPTION
The kernel expects a 4-byte in host-endian format, but '>H' in Python sends a 2-byte in big-endian format.
https://github.com/torvalds/linux/blob/21266b8df5224c4f677acf9f353eecc9094731f0/net/core/rtnetlink.c#L3329