### PR TITLE
[WIP] dhcp: use composition in AsyncDHCP4Socket

### DIFF
--- a/pyroute2/config/__init__.py
+++ b/pyroute2/config/__init__.py
@@ -33,6 +33,7 @@ if hasattr(signal, 'SIGUSR1'):
 
 mock_iproute = False
 mock_netlink = False
+mock_raw = False
 nlsocket_thread_safe = True
 
 # save uname() on startup time: it is not so

--- a/pyroute2/ext/rawsocket.py
+++ b/pyroute2/ext/rawsocket.py
@@ -9,7 +9,18 @@ from ctypes import (
     sizeof,
     string_at,
 )
-from socket import AF_PACKET, SOCK_RAW, SOL_SOCKET, errno, error, htons, socket
+from socket import (
+    AF_PACKET,
+    AF_UNIX,
+    SOCK_DGRAM,
+    SOCK_RAW,
+    SOL_SOCKET,
+    errno,
+    error,
+    htons,
+    socket,
+    socketpair,
+)
 from typing import Optional
 
 from pyroute2.iproute.linux import AsyncIPRoute
@@ -40,6 +51,128 @@ def compile_bpf(code: list[list[int]]):
     program = ProgramType(*[sock_filter(*line) for line in code])
     sfp = sock_fprog(len(code), addressof(program[0]))
     return string_at(addressof(sfp), sizeof(sfp)), program
+
+def csum(data: bytes) -> int:
+    '''Compute the "Internet checksum" for the given bytes.'''
+    if len(data) % 2:
+        data += b'\x00'
+    csum = sum(
+        [
+            struct.unpack('>H', data[x * 2 : x * 2 + 2])[0]
+            for x in range(len(data) // 2)
+        ]
+    )
+    csum = (csum >> 16) + (csum & 0xFFFF)
+    csum += csum >> 16
+    return ~csum & 0xFFFF
+
+
+class AsyncMockSocket:
+
+    async def __aexit__(self, *_):
+        self.close()
+
+    async def __aenter__(self):
+        pass
+
+    def __init__(
+        self,
+        ifname='lo',
+        bpf=None,
+        family=AF_PACKET,
+        sock_type=SOCK_RAW,
+        proto=0,
+        responses=None,
+        decoder=None,
+    ):
+        self.loopback_r, self.loopback_w = socketpair(AF_UNIX, SOCK_DGRAM)
+        self._stype = sock_type
+        self._sfamily = family
+        self._sproto = proto
+        self._bpf = bpf
+        self._ifname = ifname
+        self._decoder = decoder 
+        self.responses = responses
+        self.requests = []
+        self.decoded_requests = []
+        self.l2addr = '2e:7e:7d:8e:5f:5f'
+        for msg in self.responses or [b'bala',]:
+            self.loopback_w.send(msg)
+        if decoder is None:
+            self._decoder = lambda x: x
+
+    def close(self):
+        self.loopback_r.close()
+        self.loopback_w.close()
+
+    def bind(self, address=None):
+        pass
+
+    def fileno(self):
+        return self.loopback_r.fileno()
+
+    def recv(self, bufsize, flags=0):
+        return self.loopback_r.recv(bufsize, flags)
+
+    def recvfrom(self, bufsize, flags=0):
+        return self.loopback_r.recvfrom(bufsize, flags)
+
+    def recvmsg(self, bufsize, ancbufsize=0, flags=0):
+        return self.loopback_r.recvmsg(bufsize, ancbufsize, flags)
+
+    def recv_into(self, buffer, nbytes=0, flags=0):
+        return self.loopback_r.recv_into(buffer, nbytes, flags)
+
+    def recvfrom_into(self, buffer, nbytes=0, flags=0):
+        return self.loopback_r.recvfrom_into(buffer, nbytes, flags)
+
+    def recvmsg_into(self, buffers, ancbufsize=0, flags=0):
+        return self.loopback_r.recvmsg_into(buffers, ancbufsize, flags)
+
+    def send(self, data, flags=0):
+        print("SA", data)
+        self.requests.append(data)
+        self.decoded_requests.append(self._decoder(data))
+
+    def sendall(self, data, flags=0):
+        print("SB", data)
+        self.requests.append(data)
+        self.decoded_requests.append(self._decoder(data))
+
+    def sendto(self, data, flags, address=0):
+        raise NotImplementedError()
+
+    def sendmsg(self, buffers, ancdata=None, flags=None, address=None):
+        raise NotImplementedError()
+
+    def setblocking(self, flag):
+        return self.loopback_r.setblocking(flag)
+
+    def getblocking(self):
+        return self.loopback_r.getblocking()
+
+    def getsockname(self):
+        return self.loopback_r.getsockname()
+
+    def getpeername(self):
+        return self.loopback_r.getpeername()
+
+    @property
+    def type(self):
+        return self._stype
+
+    @property
+    def family(self):
+        return self._sfamily
+
+    @property
+    def proto(self):
+        return self._sproto
+
+    @staticmethod
+    def csum(data: bytes) -> int:
+        '''Compute the "Internet checksum" for the given bytes.'''
+        return csum(data)
 
 
 class AsyncRawSocket(socket):
@@ -117,14 +250,4 @@ class AsyncRawSocket(socket):
     @staticmethod
     def csum(data: bytes) -> int:
         '''Compute the "Internet checksum" for the given bytes.'''
-        if len(data) % 2:
-            data += b'\x00'
-        csum = sum(
-            [
-                struct.unpack('>H', data[x * 2 : x * 2 + 2])[0]
-                for x in range(len(data) // 2)
-            ]
-        )
-        csum = (csum >> 16) + (csum & 0xFFFF)
-        csum += csum >> 16
-        return ~csum & 0xFFFF
+        return csum(data)

--- a/tests/test_linux/fixtures/dhcp_servers/mock.py
+++ b/tests/test_linux/fixtures/dhcp_servers/mock.py
@@ -5,6 +5,7 @@ from fixtures.pcap_files import PcapFile
 
 from pyroute2.dhcp.dhcp4socket import AsyncDHCP4Socket
 from pyroute2.dhcp.messages import SentDHCPMessage
+from pyroute2.ext.rawsocket import AsyncMockSocket
 
 
 class MockDHCPServerFixture:
@@ -44,8 +45,10 @@ def mock_dhcp_server(
     The `pcap` fixture is used which means the pcap file must be named
     after the test.
     '''
-    responder = MockDHCPServerFixture(responses=pcap)
+    responder = AsyncMockSocket(
+        responses=pcap, decoder=AsyncDHCP4Socket._decode_msg
+    )
     monkeypatch.setattr(
-        'pyroute2.dhcp.dhcp4socket.AsyncDHCP4Socket.loop', responder
+        'pyroute2.dhcp.dhcp4socket.AsyncDHCP4Socket.socket', responder
     )
     return responder


### PR DESCRIPTION
Don't inherit from AsyncRawSocket class, but instead use it as a property.

The idea is to ease AsyncRawSocket replacement with a mock class (the commit with such mock class will follow) to run unit testing.

