### PR TITLE
nlsocket: lower log level when a port is already used

### DIFF
--- a/pyroute2/netlink/nlsocket.py
+++ b/pyroute2/netlink/nlsocket.py
@@ -331,7 +331,7 @@ class AsyncNetlinkSocket(AsyncCoreSocket):
                 except Exception as e:
                     # create a new underlying socket -- on kernel 4
                     # one failed bind() makes the socket useless
-                    log.error(e)
+                    log.debug(e)
             else:
                 raise KeyError('no free address available')
 


### PR DESCRIPTION
When a port is already used or the socket cannot be reused, it is expected to have an Exception, no need to log an error for this case.

And in case all ports are exhausted, an Exception will be raised.