### PR TITLE
Delete unused code from `./common.py`

### DIFF
--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -285,7 +285,6 @@ class AddrPool(object):
         mx = self.cell
         self.reverse = reverse
         self.release = release
-        self.allocated = 0
         if self.release and not isinstance(self.release, int):
             raise TypeError()
         self.ban = []
@@ -332,7 +331,6 @@ class AddrPool(object):
                     if self.minaddr <= ret <= self.maxaddr:
                         if self.release:
                             self.free(ret, ban=self.release)
-                        self.allocated += 1
                         return ret
                     else:
                         self.free(ret)
@@ -388,10 +386,8 @@ class AddrPool(object):
         with self.lock:
             base, bit, is_allocated = self.locate(addr)
             if value == 'free' and is_allocated:
-                self.allocated -= 1
                 self.addr_map[base] |= 1 << bit
             elif value == 'allocated' and not is_allocated:
-                self.allocated += 1
                 self.addr_map[base] &= ~(1 << bit)
 
     def free(self, addr, ban=0):
@@ -404,7 +400,6 @@ class AddrPool(object):
                     raise KeyError('address is not allocated')
                 if self.addr_map[base] & (1 << bit):
                     raise KeyError('address is not allocated')
-                self.allocated -= 1
                 self.addr_map[base] ^= 1 << bit
 
 

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -4,9 +4,7 @@ Common utilities
 '''
 import errno
 import io
-import logging
 import os
-import re
 import socket
 import struct
 import sys
@@ -14,29 +12,10 @@ import threading
 import time
 import types
 
-log = logging.getLogger(__name__)
-
-try:
-    #
-    # Python2 section
-    #
-    basestring = basestring
-    reduce = reduce
-    file = file
-
-except NameError:
-    #
-    # Python3 section
-    #
-    basestring = (str, bytes)
-    from functools import reduce
-
-    reduce = reduce
-    file = io.BytesIO
+basestring = (str, bytes)
+file = io.BytesIO
 
 AF_MPLS = 28
-AF_PIPE = 255  # Right now AF_MAX == 40
-DEFAULT_RCVBUF = 65536
 _uuid32 = 0  # (singleton) the last uuid32 value saved to avoid collisions
 _uuid32_lock = threading.Lock()
 
@@ -91,63 +70,6 @@ rate_suffixes = {
 ##
 # General purpose
 #
-class View(object):
-    '''
-    A read-only view of a dictionary object.
-    '''
-
-    def __init__(self, src=None, path=None, constraint=lambda k, v: True):
-        self.src = src if src is not None else {}
-        if path is not None:
-            path = path.split('/')
-            for step in path:
-                self.src = getattr(self.src, step)
-        self.constraint = constraint
-
-    def __getitem__(self, key):
-        if key in self.keys():
-            return self.src[key]
-        raise KeyError()
-
-    def __setitem__(self, key, value):
-        raise NotImplementedError()
-
-    def __delitem__(self, key):
-        raise NotImplementedError()
-
-    def get(self, key, default=None):
-        try:
-            return self[key]
-        except KeyError:
-            return default
-
-    def _filter(self):
-        ret = []
-        for key, value in tuple(self.src.items()):
-            try:
-                if self.constraint(key, value):
-                    ret.append((key, value))
-            except Exception as e:
-                log.error("view filter error: %s", e)
-        return ret
-
-    def keys(self):
-        return [x[0] for x in self._filter()]
-
-    def values(self):
-        return [x[1] for x in self._filter()]
-
-    def items(self):
-        return self._filter()
-
-    def __iter__(self):
-        for key in self.keys():
-            yield key
-
-    def __repr__(self):
-        return repr(dict(self._filter()))
-
-
 class Namespace(object):
     def __init__(self, parent, override=None):
         self.parent = parent
@@ -178,60 +100,6 @@ class Namespace(object):
             self.override[key] = value
         else:
             setattr(self.parent, key, value)
-
-
-class Dotkeys(dict):
-    '''
-    This is a sick-minded hack of dict, intended to be an eye-candy.
-    It allows to get dict's items by dot reference:
-
-    ipdb["lo"] == ipdb.lo
-    ipdb["eth0"] == ipdb.eth0
-
-    Obviously, it will not work for some cases, like unicode names
-    of interfaces and so on. Beside of that, it introduces some
-    complexity.
-
-    But it simplifies live for old-school admins, who works with good
-    old "lo", "eth0", and like that naming schemes.
-    '''
-
-    __var_name = re.compile('^[a-zA-Z_]+[a-zA-Z_0-9]*$')
-
-    def __dir__(self):
-        return [
-            i for i in self if isinstance(i, str) and self.__var_name.match(i)
-        ]
-
-    def __getattribute__(self, key, *argv):
-        try:
-            return dict.__getattribute__(self, key)
-        except AttributeError as e:
-            if key == '__deepcopy__':
-                raise e
-            elif key[:4] == 'set_':
-
-                def set_value(value):
-                    self[key[4:]] = value
-                    return self
-
-                return set_value
-            elif key in self:
-                return self[key]
-            else:
-                raise e
-
-    def __setattr__(self, key, value):
-        if key in self:
-            self[key] = value
-        else:
-            dict.__setattr__(self, key, value)
-
-    def __delattr__(self, key):
-        if key in self:
-            del self[key]
-        else:
-            dict.__delattr__(self, key)
 
 
 def map_namespace(prefix, ns, normalize=None):
@@ -327,10 +195,6 @@ def hexdump(payload, length=0):
     Represent byte string as hex -- for debug purposes
     '''
     return ':'.join('{0:02x}'.format(c) for c in payload[:length] or payload)
-
-
-def hexload(data):
-    return bytes(bytearray((int(x, 16) for x in data.split(':'))))
 
 
 def load_dump(f, meta=None):
@@ -544,26 +408,7 @@ class AddrPool(object):
                 self.addr_map[base] ^= 1 << bit
 
 
-def _fnv1_python2(data):
-    '''
-    FNV1 -- 32bit hash, python2 version
-
-    @param data: input
-    @type data: bytes
-
-    @return: 32bit int hash
-    @rtype: int
-
-    See: http://www.isthe.com/chongo/tech/comp/fnv/index.html
-    '''
-    hval = 0x811C9DC5
-    for i in range(len(data)):
-        hval *= 0x01000193
-        hval ^= struct.unpack('B', data[i])[0]
-    return hval & 0xFFFFFFFF
-
-
-def _fnv1_python3(data):
+def fnv1(data):
     '''
     FNV1 -- 32bit hash, python3 version
 
@@ -580,12 +425,6 @@ def _fnv1_python3(data):
         hval *= 0x01000193
         hval ^= data[i]
     return hval & 0xFFFFFFFF
-
-
-if sys.version[0] == '3':
-    fnv1 = _fnv1_python3
-else:
-    fnv1 = _fnv1_python2
 
 
 def uuid32():
@@ -664,16 +503,6 @@ def metaclass(mc):
         return mc(cls.__name__, cls.__bases__, nvars)
 
     return wrapped
-
-
-def failed_class(message):
-    class FailedClass(object):
-        def __init__(self, *argv, **kwarg):
-            ret = RuntimeError(message)
-            ret.feature_supported = False
-            raise ret
-
-    return FailedClass
 
 
 def msg_done(msg):

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -380,16 +380,6 @@ class AddrPool(object):
             is_allocated = False
         return (base, bit, is_allocated)
 
-    def setaddr(self, addr, value):
-        if value not in ('free', 'allocated'):
-            raise TypeError()
-        with self.lock:
-            base, bit, is_allocated = self.locate(addr)
-            if value == 'free' and is_allocated:
-                self.addr_map[base] |= 1 << bit
-            elif value == 'allocated' and not is_allocated:
-                self.addr_map[base] &= ~(1 << bit)
-
     def free(self, addr, ban=0):
         with self.lock:
             if ban != 0:

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -345,28 +345,6 @@ class AddrPool(object):
             else:
                 raise KeyError('no free address available')
 
-    def alloc_multi(self, count):
-        with self.lock:
-            addresses = []
-            raised = False
-            try:
-                for _ in range(count):
-                    addr = self.alloc()
-                    try:
-                        addresses.append(addr)
-                    except:
-                        # In case of a MemoryError during appending,
-                        # the finally block would not free the address.
-                        self.free(addr)
-                return addresses
-            except:
-                raised = True
-                raise
-            finally:
-                if raised:
-                    for addr in addresses:
-                        self.free(addr)
-
     def locate(self, addr):
         if self.reverse:
             addr = self.maxaddr - addr

--- a/tests/test_unit/test_addr_pool.py
+++ b/tests/test_unit/test_addr_pool.py
@@ -52,7 +52,6 @@ def test_locate():
     assert bit2 == bit1 + 1
     assert is_allocated1
     assert not is_allocated2
-    assert ap.allocated == 1
 
 
 def test_setaddr_allocated():
@@ -60,15 +59,12 @@ def test_setaddr_allocated():
     f = ap.alloc()
     base, bit, is_allocated = ap.locate(f + 1)
     assert not is_allocated
-    assert ap.allocated == 1
     ap.setaddr(f + 1, 'allocated')
     base, bit, is_allocated = ap.locate(f + 1)
     assert is_allocated
-    assert ap.allocated == 2
     ap.free(f + 1)
     base, bit, is_allocated = ap.locate(f + 1)
     assert not is_allocated
-    assert ap.allocated == 1
 
 
 def test_setaddr_free():
@@ -76,14 +72,11 @@ def test_setaddr_free():
     f = ap.alloc()
     base, bit, is_allocated = ap.locate(f + 1)
     assert not is_allocated
-    assert ap.allocated == 1
     ap.setaddr(f + 1, 'free')
     base, bit, is_allocated = ap.locate(f + 1)
     assert not is_allocated
-    assert ap.allocated == 1
     ap.setaddr(f, 'free')
     base, bit, is_allocated = ap.locate(f)
     assert not is_allocated
-    assert ap.allocated == 0
     with pytest.raises(KeyError):
         ap.free(f)

--- a/tests/test_unit/test_addr_pool.py
+++ b/tests/test_unit/test_addr_pool.py
@@ -52,31 +52,3 @@ def test_locate():
     assert bit2 == bit1 + 1
     assert is_allocated1
     assert not is_allocated2
-
-
-def test_setaddr_allocated():
-    ap = AddrPool()
-    f = ap.alloc()
-    base, bit, is_allocated = ap.locate(f + 1)
-    assert not is_allocated
-    ap.setaddr(f + 1, 'allocated')
-    base, bit, is_allocated = ap.locate(f + 1)
-    assert is_allocated
-    ap.free(f + 1)
-    base, bit, is_allocated = ap.locate(f + 1)
-    assert not is_allocated
-
-
-def test_setaddr_free():
-    ap = AddrPool()
-    f = ap.alloc()
-    base, bit, is_allocated = ap.locate(f + 1)
-    assert not is_allocated
-    ap.setaddr(f + 1, 'free')
-    base, bit, is_allocated = ap.locate(f + 1)
-    assert not is_allocated
-    ap.setaddr(f, 'free')
-    base, bit, is_allocated = ap.locate(f)
-    assert not is_allocated
-    with pytest.raises(KeyError):
-        ap.free(f)

--- a/tests/test_unit/test_common.py
+++ b/tests/test_unit/test_common.py
@@ -1,15 +1,4 @@
-from pyroute2.common import dqn2int, hexdump, hexload, uifname, uuid32
-
-
-def test_hexdump():
-    binary = b'abcdef5678'
-    dump1 = hexdump(binary)
-    dump2 = hexdump(binary, length=6)
-    assert len(dump1) == 29
-    assert len(dump2) == 17
-    assert dump1[2] == dump1[-3] == dump2[2] == dump2[-3] == ':'
-    assert hexload(dump1) == binary
-    assert hexload(dump2) == binary[:6]
+from pyroute2.common import dqn2int, uifname, uuid32
 
 
 def test_uuid32():


### PR DESCRIPTION
Deletion of unused code in `pyroute2/common.py`:

- Python 2 related chunk
- Classes: `View` and `DotKeys`
- Functions: `hexload`, `_fnv1_python2` and `failed_class`
- Constants: `AF_PIPE` and `DEFAULT_RCVBUF`

Take extra attention to deletion of:

- `AddrPool.allocated`
- `AddrPool.alloc_multi`
- `AddrPool.setaddr`

...because I hope I checked usage of these attributes, however, I am not 100% sure