### PR TITLE
netlink/core: give a chance for socket to close

### DIFF
--- a/pyroute2/netlink/core.py
+++ b/pyroute2/netlink/core.py
@@ -389,6 +389,8 @@ class AsyncCoreSocket:
                 if sock is not None:
                     sock.close()
                 if self.status['event_loop'] == 'new':
+                    # go to the event loop to really close the transport
+                    event_loop.run_until_complete(event_loop.shutdown_asyncgens())
                     event_loop.stop()
                     event_loop.close()
             self.__all_open_resources = tuple()


### PR DESCRIPTION
transport.close() does not really close the socket, but move the transport to "closing" state.

We need to give some time to the event loop for a real closed object

Before the patch:

$ python3 -X dev -c "from pyroute2 import IPRoute ; ip = IPRoute() ; ip.close()"
/usr/lib/python3.11/asyncio/selector_events.py:843: ResourceWarning: unclosed transport <_SelectorDatagramTransport closing fd=6>