### PR TITLE
Types for the `pyroute2.common`

### DIFF
--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -7,7 +7,6 @@ import io
 import os
 import socket
 import struct
-import sys
 import threading
 import time
 import types

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -205,7 +205,7 @@ def dqn2int(mask: str, family: socket.AddressFamily = socket.AF_INET) -> int:
     return ret
 
 
-def get_address_family(address):
+def get_address_family(address: str) -> socket.AddressFamily:
     if address.find(':') > -1:
         return socket.AF_INET6
     else:

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -436,13 +436,18 @@ def uifname() -> str:
     return 'pr%x' % uuid32()
 
 
-def map_exception(match, subst):
+F = TypeVar("F", bound=Callable[..., Any])
+
+def map_exception(
+    match: Callable[[Exception], bool],
+    subst: Callable[[Exception], Exception]
+) -> Callable[[F], F]:
     '''
     Decorator to map exception types
     '''
 
-    def wrapper(f):
-        def decorated(*argv, **kwarg):
+    def wrapper(f: F) -> F:
+        def decorated(*argv: Any, **kwarg: Any) -> Any:
             try:
                 f(*argv, **kwarg)
             except Exception as e:
@@ -450,7 +455,7 @@ def map_exception(match, subst):
                     raise subst(e)
                 raise
 
-        return decorated
+        return decorated  # type: ignore
 
     return wrapper
 

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -162,16 +162,20 @@ def map_namespace(
     return (by_name, by_value)
 
 
-def getbroadcast(addr, mask, family=socket.AF_INET):
+def getbroadcast(
+    addr: str,
+    mask: int,
+    family: socket.AddressFamily = socket.AF_INET
+) -> str:
     # 1. convert addr to int
     i = socket.inet_pton(family, addr)
     if family == socket.AF_INET:
-        i = struct.unpack('>I', i)[0]
+        i_unpacked = struct.unpack('>I', i)[0]
         a = 0xFFFFFFFF
         length = 32
     elif family == socket.AF_INET6:
-        i = struct.unpack('>QQ', i)
-        i = i[0] << 64 | i[1]
+        i_unpacked = struct.unpack('>QQ', i)
+        i_unpacked = i_unpacked[0] << 64 | i_unpacked[1]
         a = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
         length = 128
     else:
@@ -179,7 +183,7 @@ def getbroadcast(addr, mask, family=socket.AF_INET):
     # 2. calculate mask
     m = (a << length - mask) & a
     # 3. calculate default broadcast
-    n = (i & m) | a >> mask
+    n = (i_unpacked & m) | a >> mask
     # 4. convert it back to the normal address form
     if family == socket.AF_INET:
         n = struct.pack('>I', n)

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -162,9 +162,7 @@ def map_namespace(
 
 
 def getbroadcast(
-    addr: str,
-    mask: int,
-    family: socket.AddressFamily = socket.AF_INET
+    addr: str, mask: int, family: socket.AddressFamily = socket.AF_INET
 ) -> str:
     # 1. convert addr to int
     i = socket.inet_pton(family, addr)
@@ -304,7 +302,7 @@ class AddrPool(object):
         minaddr: int = 0xF,
         maxaddr: int = 0xFFFFFF,
         reverse: bool = False,
-        release: bool = False
+        release: bool = False,
     ):
         self.cell_size = 0  # in bits
         mx = self.cell
@@ -437,9 +435,9 @@ def uifname() -> str:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+
 def map_exception(
-    match: Callable[[Exception], bool],
-    subst: Callable[[Exception], Exception]
+    match: Callable[[Exception], bool], subst: Callable[[Exception], Exception]
 ) -> Callable[[F], F]:
     '''
     Decorator to map exception types
@@ -470,6 +468,7 @@ def map_enoent(f: F) -> F:
 
 
 T = TypeVar('T', bound=type)
+
 
 def metaclass(mc: T) -> Callable[[T], T]:
     def wrapped(cls: T) -> T:

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -192,7 +192,7 @@ def getbroadcast(
     return socket.inet_ntop(family, n)
 
 
-def dqn2int(mask, family=socket.AF_INET):
+def dqn2int(mask: str, family: socket.AddressFamily = socket.AF_INET) -> int:
     '''
     IPv4 dotted quad notation to int mask conversion
     '''

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -460,7 +460,7 @@ def map_exception(
     return wrapper
 
 
-def map_enoent(f):
+def map_enoent(f: F) -> F:
     '''
     Shortcut to map OSError(2) -> OSError(95)
     '''

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -395,15 +395,11 @@ class AddrPool(object):
                 self.addr_map[base] ^= 1 << bit
 
 
-def fnv1(data):
+def fnv1(data: bytes) -> int:
     '''
     FNV1 -- 32bit hash, python3 version
 
-    @param data: input
-    @type data: bytes
-
-    @return: 32bit int hash
-    @rtype: int
+    Returns: 32bit int hash
 
     See: http://www.isthe.com/chongo/tech/comp/fnv/index.html
     '''

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -410,12 +410,9 @@ def fnv1(data: bytes) -> int:
     return hval & 0xFFFFFFFF
 
 
-def uuid32():
+def uuid32() -> int:
     '''
     Return 32bit UUID, based on the current time and pid.
-
-    @return: 32bit int uuid
-    @rtype: int
 
     The uuid is guaranteed to be unique within one process.
     '''

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -11,7 +11,7 @@ import threading
 import time
 import types
 from functools import partial
-from typing import Any, Callable, Literal, TypeVar, Union
+from typing import Any, Callable, Literal, Optional, TypeVar, Union
 
 basestring = (str, bytes)
 file = io.BytesIO
@@ -73,7 +73,7 @@ rate_suffixes = {
 #
 class Namespace(object):
     def __init__(
-        self, parent: 'Namespace', override: Union[dict[str, Any], None] = None
+        self, parent: 'Namespace', override: Optional[dict[str, Any]] = None
     ):
         self.parent = parent
         self.override = override or {}

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -301,15 +301,17 @@ class AddrPool(object):
     cell = 0xFFFFFFFFFFFFFFFF
 
     def __init__(
-        self, minaddr=0xF, maxaddr=0xFFFFFF, reverse=False, release=False
+        self,
+        minaddr: int = 0xF,
+        maxaddr: int = 0xFFFFFF,
+        reverse: bool = False,
+        release: bool = False
     ):
         self.cell_size = 0  # in bits
         mx = self.cell
         self.reverse = reverse
         self.release = release
-        if self.release and not isinstance(self.release, int):
-            raise TypeError()
-        self.ban = []
+        self.ban: list[dict[str, int]] = []
         while mx:
             mx >>= 8
             self.cell_size += 1
@@ -322,7 +324,7 @@ class AddrPool(object):
         self.maxaddr = maxaddr
         self.lock = threading.RLock()
 
-    def alloc(self):
+    def alloc(self) -> int:
         with self.lock:
             # gc self.ban:
             for item in tuple(self.ban):
@@ -367,7 +369,7 @@ class AddrPool(object):
             else:
                 raise KeyError('no free address available')
 
-    def locate(self, addr):
+    def locate(self, addr: int) -> tuple[int, int, bool]:
         if self.reverse:
             addr = self.maxaddr - addr
         else:
@@ -380,12 +382,12 @@ class AddrPool(object):
             is_allocated = False
         return (base, bit, is_allocated)
 
-    def free(self, addr, ban=0):
+    def free(self, addr: int, ban: int = 0):
         with self.lock:
             if ban != 0:
                 self.ban.append({'addr': addr, 'counter': ban})
             else:
-                base, bit, is_allocated = self.locate(addr)
+                base, bit, _ = self.locate(addr)
                 if len(self.addr_map) <= base:
                     raise KeyError('address is not allocated')
                 if self.addr_map[base] & (1 << bit):

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -212,7 +212,7 @@ def get_address_family(address: str) -> socket.AddressFamily:
         return socket.AF_INET
 
 
-def hexdump(payload, length=0):
+def hexdump(payload: bytes, length: int = 0) -> str:
     '''
     Represent byte string as hex -- for debug purposes
     '''

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -489,7 +489,7 @@ def metaclass(mc: T) -> Callable[[T], T]:
     return wrapped
 
 
-def msg_done(msg):
+def msg_done(msg) -> bytes:
     newmsg = struct.pack('IHH', 40, 2, 0)
     newmsg += msg.data[8:16]
     newmsg += struct.pack('I', 0)

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -146,7 +146,7 @@ def map_namespace(
         - True — cut the prefix and `lower()` the rest
         - lambda x: … — apply the function to every name
     '''
-    nmap = {None: lambda x: x, True: lambda x: x[len(prefix) :].lower()}
+    transform: Callable[[str], str]
 
     if normalize is None:
         transform = _no_change
@@ -157,12 +157,8 @@ def map_namespace(
     else:
         raise ValueError("Invalid value for `normalize` parameter")
 
-    by_name = dict(
-        [(normalize(i), ns[i]) for i in ns.keys() if i.startswith(prefix)]
-    )
-    by_value = dict(
-        [(ns[i], normalize(i)) for i in ns.keys() if i.startswith(prefix)]
-    )
+    by_name = {transform(i): ns[i] for i in ns.keys() if i.startswith(prefix)}
+    by_value = {ns[i]: transform(i) for i in ns.keys() if i.startswith(prefix)}
     return (by_name, by_value)
 
 

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -472,7 +472,6 @@ def map_enoent(f: F) -> F:
 
 T = TypeVar('T', bound=type)
 
-
 def metaclass(mc: T) -> Callable[[T], T]:
     def wrapped(cls: T) -> T:
         nvars = {}

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -217,7 +217,7 @@ def hexdump(payload: bytes, length: int = 0) -> str:
 
 
 def load_dump(
-    f: Union[str, io.StringIO], meta: Union[dict[str, str], None] = None
+    f: Union[str, io.StringIO], meta: Optional[dict[str, str]] = None
 ) -> Union[bytes, str]:
     '''
     Load a packet dump from an open file-like object or a string.

--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -429,12 +429,9 @@ def uuid32() -> int:
         return candidate
 
 
-def uifname():
+def uifname() -> str:
     '''
     Return a unique interface name based on a prime function
-
-    @return: interface name
-    @rtype: str
     '''
     return 'pr%x' % uuid32()
 

--- a/tests/test_unit/test_common.py
+++ b/tests/test_unit/test_common.py
@@ -1,4 +1,4 @@
-from pyroute2.common import dqn2int, uifname, uuid32
+from pyroute2.common import dqn2int, map_namespace, uifname, uuid32
 
 
 def test_uuid32():
@@ -23,3 +23,56 @@ def test_uifname():
     nB = uifname()
     assert nA != nB
     assert int(nA[2:], 16) != int(nB[2:], 16)
+
+
+def test_map_namespace():
+    others = {
+        'IFNAMSIZ': 16,
+        '__name__': 'pyroute2.bsd.pf_route.freebsd',
+        '__doc__': None,
+    }
+    prefixed = {'IFF_UP': 1, 'IFF_NOGROUP': 8388608}
+    prefixed_by_value = {1: 'IFF_UP', 8388608: 'IFF_NOGROUP'}
+    ns = prefixed | others
+
+    by_name, by_value = map_namespace('IFF', ns)
+
+    assert by_name == prefixed
+    assert by_value == prefixed_by_value
+
+
+def test_map_namespace_normalize():
+    others = {
+        'IFNAMSIZ': 16,
+        '__name__': 'pyroute2.bsd.pf_route.freebsd',
+        '__doc__': None,
+    }
+    prefixed = {'IFF_UP': 1, 'IFF_NOGROUP': 8388608}
+    normalized = {'_up': 1, '_nogroup': 8388608}
+    normalized_by_value = {1: '_up', 8388608: '_nogroup'}
+    ns = prefixed | others
+
+    by_name, by_value = map_namespace('IFF', ns, True)
+
+    assert by_name == normalized
+    assert by_value == normalized_by_value
+
+
+def test_map_namespace_normalize_function():
+    def normalizer(s: str) -> str:
+        return s.removeprefix('IFF_')
+
+    others = {
+        'IFNAMSIZ': 16,
+        '__name__': 'pyroute2.bsd.pf_route.freebsd',
+        '__doc__': None,
+    }
+    prefixed = {'IFF_UP': 1, 'IFF_NOGROUP': 8388608}
+    normalized = {'UP': 1, 'NOGROUP': 8388608}
+    normalized_by_value = {1: 'UP', 8388608: 'NOGROUP'}
+    ns = prefixed | others
+
+    by_name, by_value = map_namespace('IFF', ns, normalizer)
+
+    assert by_name == normalized
+    assert by_value == normalized_by_value


### PR DESCRIPTION
Couldn't infer type for `msg_done` function.

Linter would warn about two lambda functions, but I saved them, since one of them is actually closure, so that would complicate typing too much.

Other than typing, following changes were done:
- `map_namespace` were re-written to be more explicit. Tests are added
- `load_dump` Python 2 code was removed