### PR TITLE
dhcp: interface name can have a vlan in it

### DIFF
--- a/pyroute2/dhcp/client.py
+++ b/pyroute2/dhcp/client.py
@@ -98,7 +98,11 @@ class ClientConfig:
     @property
     def pidfile_path(self) -> Path:
         '''Where to write the pid file. It's named after the interface.'''
-        return Path.cwd().joinpath(self.interface).with_suffix('.pid')
+        return (
+            Path.cwd()
+            .joinpath(self.interface)
+            .with_name(f"{self.interface}.pid")
+        )
 
 
 class AsyncDHCPClient:

--- a/pyroute2/dhcp/leases.py
+++ b/pyroute2/dhcp/leases.py
@@ -211,7 +211,9 @@ class JSONFileLease(Lease):
     def _get_path(cls, interface: str) -> Path:
         '''The lease file, named after the interface.'''
         return (
-            cls._get_lease_dir().joinpath(interface).with_suffix('.lease.json')
+            cls._get_lease_dir()
+            .joinpath(interface)
+            .with_name(f'{interface}.lease.json')
         )
 
     def dump(self) -> None:


### PR DESCRIPTION
The way it was done, if the interface name had a vlan in it (example eth1.100), since we're using the `with_suffix` function it would remove the vlan and save the files as `eth1.pid` and `eth1.lease.json`