### PR TITLE
dhcp server detector: use a different xid per interface

### DIFF
--- a/pyroute2/dhcp/fsm.py
+++ b/pyroute2/dhcp/fsm.py
@@ -50,7 +50,7 @@ def state_guard(
     if the associated instance is not in one of the given States.'''
 
     def decorator(
-        meth: Callable[..., Awaitable[None]]
+        meth: Callable[..., Awaitable[None]],
     ) -> Callable[..., Awaitable[None]]:
         @functools.wraps(meth)
         async def wrapper(self, *args: Any, **kwargs: Any) -> None:

--- a/pyroute2/dhcp/fsm.py
+++ b/pyroute2/dhcp/fsm.py
@@ -50,7 +50,7 @@ def state_guard(
     if the associated instance is not in one of the given States.'''
 
     def decorator(
-        meth: Callable[..., Awaitable[None]],
+        meth: Callable[..., Awaitable[None]]
     ) -> Callable[..., Awaitable[None]]:
         @functools.wraps(meth)
         async def wrapper(self, *args: Any, **kwargs: Any) -> None:

--- a/pyroute2/dhcp/messages.py
+++ b/pyroute2/dhcp/messages.py
@@ -42,7 +42,10 @@ class SentDHCPMessage(_DHCPMessage):
 
     def __str__(self) -> str:
         type_name = self.message_type.name
-        return f"{type_name} to {self.eth_dst}/{self.ip_dst}:{self.dport}"
+        return (
+            f'{type_name} to {self.eth_dst}/{self.ip_dst}:{self.dport} '
+            '(xid {self.xid})'
+        )
 
 
 class ReceivedDHCPMessage(_DHCPMessage):
@@ -50,7 +53,10 @@ class ReceivedDHCPMessage(_DHCPMessage):
 
     def __str__(self) -> str:
         type_name = self.dhcp['options']['message_type'].name
-        return f"{type_name} from {self.eth_src}/{self.ip_src}:{self.sport}"
+        return (
+            f'{type_name} from {self.eth_src}/{self.ip_src}:{self.sport} '
+            '(xid {self.xid})'
+        )
 
 
 def discover(parameter_list: Parameters) -> SentDHCPMessage:

--- a/pyroute2/dhcp/messages.py
+++ b/pyroute2/dhcp/messages.py
@@ -44,7 +44,7 @@ class SentDHCPMessage(_DHCPMessage):
         type_name = self.message_type.name
         return (
             f'{type_name} to {self.eth_dst}/{self.ip_dst}:{self.dport} '
-            '(xid {self.xid})'
+            f'(xid {self.xid})'
         )
 
 
@@ -55,7 +55,7 @@ class ReceivedDHCPMessage(_DHCPMessage):
         type_name = self.dhcp['options']['message_type'].name
         return (
             f'{type_name} from {self.eth_src}/{self.ip_src}:{self.sport} '
-            '(xid {self.xid})'
+            f'(xid {self.xid})'
         )
 
 

--- a/pyroute2/dhcp/server_detector.py
+++ b/pyroute2/dhcp/server_detector.py
@@ -98,11 +98,11 @@ class DHCPServerDetector:
                     if next_msg.dhcp['xid'] != expected_xids[sock.ifname]:
                         LOG.debug(
                             '[%s] Got %s with xid mismatch, ignoring',
-                            sock.ifname,
+                            interface,
                             next_msg.message_type.name,
                         )
                         continue
-                    LOG.info('[%s] <- %s', sock.ifname, next_msg)
+                    LOG.info('[%s] <- %s', interface, next_msg)
                     await self._responses_queue.put((interface, next_msg))
                 except asyncio.CancelledError:
                     LOG.debug('[%s] stop discovery', interface)

--- a/pyroute2/dhcp/server_detector.py
+++ b/pyroute2/dhcp/server_detector.py
@@ -97,9 +97,9 @@ class DHCPServerDetector:
                     next_msg = await get_next_msg
                     if next_msg.dhcp['xid'] != expected_xids[sock.ifname]:
                         LOG.debug(
-                            '[%s] Got %r with xid mismatch, ignoring',
+                            '[%s] Got %s with xid mismatch, ignoring',
                             sock.ifname,
-                            next_msg.message_type,
+                            next_msg.message_type.name,
                         )
                         continue
                     LOG.info('[%s] <- %s', sock.ifname, next_msg)

--- a/pyroute2/dhcp/xids.py
+++ b/pyroute2/dhcp/xids.py
@@ -1,5 +1,5 @@
 from secrets import SystemRandom
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pyroute2.dhcp.fsm import State
 
@@ -25,8 +25,10 @@ class Xid:
     the same value when answering. (see RFC section 4.1)
     '''
 
-    def __init__(self, value: Optional[int] = None):
-        if value is None:
+    def __init__(self, value: Optional[Union[int, 'Xid']] = None):
+        if isinstance(value, Xid):
+            value = value._value
+        elif value is None:
             value = random_xid_prefix()
         else:
             assert value < 0xFFFFFFFF  # we have 32 bits

--- a/pyroute2/ext/bpf.py
+++ b/pyroute2/ext/bpf.py
@@ -1,0 +1,89 @@
+from ctypes import (
+    Structure,
+    addressof,
+    c_int,
+    c_ubyte,
+    c_ushort,
+    c_void_p,
+    sizeof,
+    string_at,
+)
+from enum import IntEnum
+
+
+class sock_filter(Structure):
+    _fields_ = [
+        ('code', c_ushort),  # u16
+        ('jt', c_ubyte),  # u8
+        ('jf', c_ubyte),  # u8
+        ('k', c_int),  # can be signed or unsigned
+    ]
+
+
+class sock_fprog(Structure):
+    _fields_ = [('len', c_ushort), ('filter', c_void_p)]
+
+
+def compile(code: list[list[int]]):
+    ProgramType = sock_filter * len(code)
+    program = ProgramType(*[sock_filter(*line) for line in code])
+    sfp = sock_fprog(len(code), addressof(program[0]))
+    return string_at(addressof(sfp), sizeof(sfp)), program
+
+
+class BPF(IntEnum):
+    '''BPF constants.
+
+    See:
+    - https://www.kernel.org/doc/Documentation/networking/filter.txt
+    - https://github.com/iovisor/bpf-docs/blob/master/eBPF.md
+    '''
+
+    # Operations
+    LD = 0x00  # Load
+    LDX = 0x01  # Load Index
+    ST = 0x02  # Store
+    STX = 0x03  # Store Index
+    ALU = 0x04  # Arithmetic Logic Unit
+    JMP = 0x05  # Jump
+    RET = 0x06  # Return
+    MISC = 0x07  # Miscellaneous
+
+    # Sizes
+    W = 0x00  # Word (4 bytes)
+    H = 0x08  # Half-word (2 bytes)
+    B = 0x10  # Byte (1 byte)
+
+    # Offsets
+    IMM = 0x00  # Immediate
+    ABS = 0x20  # Absolute
+    IND = 0x40  # Indirect
+    MEM = 0x60  # Memory
+    LEN = 0x80  # Packet Length
+    MSH = 0xA0  # Masked
+
+    # gotos
+    JEQ = 0x10  # Jump if Equal
+    JGT = 0x20  # Jump if Greater
+    JGE = 0x30  # Jump if Greater or Equal
+    JSET = 0x40  # Jump if Bit is Set
+
+    # Sources
+    K = 0x00  # Constant
+    X = 0x08  # Register
+
+    # Operators
+    ADD = 0x00
+    SUB = 0x10
+    MUL = 0x20
+    DIV = 0x30
+    OR = 0x40
+    AND = 0x50
+    LSH = 0x60
+    RSH = 0x70
+    NEG = 0x80
+    MOD = 0x90
+    XOR = 0xA0
+    MOV = 0xB0
+    ARSH = 0xC0
+    END = 0xD0


### PR DESCRIPTION
We noticed an issue when using the dhcp server detector over a vlan, i have to test & reproduce it but using a different xid for each interface will help