### PR TITLE
ndb.objects.interface: fix setns

### DIFF
--- a/pyroute2/ndb/objects/interface.py
+++ b/pyroute2/ndb/objects/interface.py
@@ -1037,13 +1037,13 @@ class Interface(RTNL_Object):
             if 'alt_ifname_list' in self.changed:
                 self.changed.remove('alt_ifname_list')
             super(Interface, self).apply(rollback, req_filter, mode)
-            if setns:
+            if setns and self['net_ns_fd'] in self.sources:
                 self.load_value('target', self['net_ns_fd'])
                 dict.__setitem__(self, 'net_ns_fd', None)
                 spec = self.load_sql()
                 if spec:
                     self.state.set('system')
-            if not remove:
+            if not remove and self.state != 'invalid':
                 self.apply_altnames(
                     alt_ifname_setup, set(self['alt_ifname_list']), old_ifname
                 )


### PR DESCRIPTION
Fix setns operations when the netns is not in the sources:

```
with NDB() as ndb:
	with ndb.interfaces['port0'] as i:
		i['net_ns_fd'] = 'test'
```

OBS: it should work with the source as well:

```
with NDB() as ndb:
	ndb.sources.add(netns='test')
	with ndb.interfaces['port0'] as i:
		i['net_ns_fd'] = 'test'
```

In this case the interface state should be 'system' instead of 'invalid'.

Bug-Url: https://github.com/svinota/pyroute2/issues/1181