### PR TITLE
ioctl: Remove assert on mask when retrieving string set info

### DIFF
--- a/pyroute2/ethtool/ioctl.py
+++ b/pyroute2/ethtool/ioctl.py
@@ -538,7 +538,6 @@ class IoctlEthtool:
         ifreq_sset.ifr_name = (ctypes.c_uint8 * IFNAMSIZ)(*self.ifname)
         ifreq_sset.info = ctypes.pointer(sset_info)
         fcntl.ioctl(self.sock, SIOCETHTOOL, ifreq_sset)
-        assert sset_info.sset_mask
         return sset_info.data
 
     def get_stringset(


### PR DESCRIPTION
We stumbled upon a case where the mask is empty, when retrieving the statistics of a virtual interface created on a bonding of two physical interfaces.

In this case, `ethtool` simply return empty statistics, either from ioctl or netlink :
```
# ethtool -S eth0 --all-groups
Standard stats for eth0:
# ethtool -S eth0
no stats available
```

And looking at the kernel code, we can see that the mask is first zeroed [1] then filled only on success [2], meaning that an empty mask is possible.

[1]: https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ethtool/ioctl.c#n797
[2]: https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ethtool/ioctl.c#n814
