### PR TITLE
dhcp client: do not crash when failing to write a lease

### DIFF
--- a/pyroute2/dhcp/client.py
+++ b/pyroute2/dhcp/client.py
@@ -218,7 +218,12 @@ class AsyncDHCPClient:
             rebinding=self._rebind,
             expiration=self._expire_lease,
         )
-        self._lease.dump()
+        # whatever error might happen when writing a lease,
+        # it should never make the client crash
+        try:
+            self._lease.dump()
+        except Exception as exc:
+            LOG.error('Could not dump lease: %s', exc)
 
     @property
     def state(self) -> fsm.State:


### PR DESCRIPTION
In the unlikely event the lease cannot be written to disk (read only file system ? removed working dir ? undumpable JSON ?), the client shouldn't crash but simply log an error. The only consequence is that the client won't load the lease on next startup.