### PR TITLE
ethtool/ioctl: Use byref instead of cpointer when possible

### DIFF
--- a/pyroute2/ethtool/ioctl.py
+++ b/pyroute2/ethtool/ioctl.py
@@ -524,7 +524,7 @@ class IoctlEthtool:
             cmd=ETHTOOL_GSTATS
         )
         self.ifreq.gstats = ctypes.cast(
-            ctypes.pointer(gstats), ctypes.POINTER(None)
+            ctypes.byref(gstats), ctypes.POINTER(None)
         )
         self.ioctl()
         assert len(self.stat_names) == len(gstats.data)
@@ -551,7 +551,7 @@ class IoctlEthtool:
             cmd=ETHTOOL_GSTRINGS, string_set=set_id, len=gstrings_length
         )
         self.ifreq.gstrings = ctypes.cast(
-            ctypes.pointer(gstrings), ctypes.POINTER(None)
+            ctypes.byref(gstrings), ctypes.POINTER(None)
         )
         self.ioctl()
 


### PR DESCRIPTION
According to the ctypes documentation [1], calling cpointer creates a new instance, and it seems to lead to memory leaks: "Note that ctypes does not have OOR (original object return), it constructs a new, equivalent object each time you retrieve an attribute".

The cpointer documentation [2] indicates that byref should rather be used when passing "a pointer to an object to a foreign function call".

[1]: https://docs.python.org/3/library/ctypes.html#pointers
[2]: https://docs.python.org/3/library/ctypes.html#ctypes.pointer

### Reproducer 
The following reproducer shows the memory leak:
```python
#!/usr/bin/python3
import psutil
from pyroute2.ethtool import Ethtool


def main():
    process = psutil.Process()
    memory = []

    with Ethtool() as ethtool:
        for idx in range(10001):
            ethtool._with_ioctl.change_ifname("enp11s0")
            ethtool._with_ioctl.get_statistics()
            if idx % 1000 == 0:
                memory.append(round(process.memory_info().rss / 1024 / 1024, 2))

    print(memory)


if __name__ == "__main__":
    main()
```

Without the fix, on my computer:
```
$ ./reproducer.py
[39.05, 50.42, 62.05, 73.92, 85.42, 96.92, 109.17, 120.67, 132.17, 143.55, 155.05]
```

With the fix, on my computer:
```
$ ./reproducer.py
[38.92, 39.05, 39.05, 39.05, 39.05, 39.05, 39.05, 39.05, 39.05, 39.05, 39.05]
```