### PR TITLE
common: introduce time.CLOCK_BOOTTIME to compute timeout

### DIFF
--- a/pyroute2/common.py
+++ b/pyroute2/common.py
@@ -466,3 +466,14 @@ def msg_done(msg) -> bytes:
     # nlmsgerr struct alignment
     newmsg += b'\0' * 20
     return newmsg
+
+
+def get_boottime() -> float:
+    '''
+    Return seconds since arbitrary start point (boot)
+
+    It cannot go backward. It includes any time that the system is suspended.
+    You should use this instead of time.time() to measure time between two
+    execution points, like a timeout.
+    '''
+    return time.clock_gettime(time.CLOCK_BOOTTIME)

--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -11,7 +11,7 @@ from functools import partial
 from socket import AF_INET, AF_INET6, AF_UNSPEC
 
 from pyroute2 import config, netns
-from pyroute2.common import AF_MPLS, basestring
+from pyroute2.common import AF_MPLS, basestring, get_boottime
 from pyroute2.netlink import NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST, NLMSG_ERROR
 from pyroute2.netlink.exceptions import (
     NetlinkDumpInterrupted,
@@ -447,9 +447,9 @@ class RTNL_API:
             except TimeoutError:
                 pass
         '''
-        ctime = time.time()
+        ctime = get_boottime()
         ret = tuple()
-        while ctime + timeout > time.time():
+        while ctime + timeout > get_boottime():
             try:
                 ret = await method(command, **spec)
                 if not isinstance(ret, list):
@@ -2736,9 +2736,9 @@ class IPRoute(NetlinkSocket):
         )
 
     def poll(self, method, command, timeout=10, interval=0.2, **spec):
-        ctime = time.time()
+        ctime = get_boottime()
         ret = tuple()
-        while ctime + timeout > time.time():
+        while ctime + timeout > get_boottime():
             try:
                 ret = [x for x in method(command, **spec)]
                 if ret:

--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -52,11 +52,10 @@ import logging
 import os
 import os.path
 import socket
-import time
 from typing import Optional
 
 from pyroute2 import config
-from pyroute2.common import USE_DEFAULT_TIMEOUT, basestring
+from pyroute2.common import USE_DEFAULT_TIMEOUT, basestring, get_boottime
 from pyroute2.process import ChildProcess, ChildProcessReturnValue
 
 log = logging.getLogger(__name__)
@@ -391,8 +390,8 @@ def create_socket(
     if timeout == USE_DEFAULT_TIMEOUT:
         timeout = config.default_create_socket_timeout
 
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = get_boottime()
+    while get_boottime() - start_time < timeout:
         with ChildProcess(
             target=_create_socket_child,
             args=[netns, flags, family, socket_type, proto, libc],


### PR DESCRIPTION
time.time() is dangerous since in case of clock synchronization:
 * it can go backward and produce weird effects
 * it can go forward with a big jump

time.CLOCK_BOOTTIME provides safety for timeout checks.

See https://docs.python.org/3/library/time.html#time.CLOCK_BOOTTIME

One drawback: it is only available on Linux, after 2.6.39 version