### PR TITLE
iproute: Fixed the request parser, so that it accepts {'dst_len': 0, 'dst': "0.0.0.0"} without an OSError

### DIFF
--- a/pyroute2/requests/common.py
+++ b/pyroute2/requests/common.py
@@ -108,11 +108,11 @@ class IPTargets:
 
     def set_dst(self, context, value):
         if value in ('', 'default'):
-            return {'dst': ''}
-        elif value in ('0', '0.0.0.0'):
-            return {'dst': '', 'family': AF_INET}
+            return {}
+        elif value in ('0', '0.0.0.0', '0.0.0.0/0'):
+            return {'family': AF_INET}
         elif value in ('::', '::/0'):
-            return {'dst': '', 'family': AF_INET6}
+            return {'family': AF_INET6}
         return self.parse_target('dst', context, value)
 
     def set_src(self, context, value):


### PR DESCRIPTION
Hello,

while fixing an issue in another project, I noticed that when I passed both a `dst_len=0` and a (redundant) `dst="0.0.0.0"` into `IPRoute.rule("delete", ...)` pyroute2 would throw an exception.
Specifically, it was `socket.inet_pton` that threw `OSError: illegal IP address string passed to inet_pton`.
After closer inspection, I realized that pyroute2 was passing an empty string to the function, which is invalid in [Linux's implementation](https://www.man7.org/linux/man-pages/man3/inet_pton.3.html).
Following the value backwards, to see where it gets replaced, I'm pretty sure that I found the place in `requests/common.py` (see commit).
Just making it not return any value for `dst` seemed to fix the issue.
I'm not familiar with the codebase but I think the only other place where this is used is in routes, which seems to still work after brief testing. However, there could be bigger repercussions that I'm not aware of.

Additionally I added `0.0.0.0/0` to the values that qualify as an `any` address, because the `/0` suffix is in the list for `AF_INET6` as well.