### PR TITLE
Add iproute "rt files" management

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -120,11 +120,11 @@ def get_default_request_filters(mode, command):
     return filters[mode]
 
 
-def get_dump_filter(mode, command, query):
+def get_dump_filter(mode, command, query, parameters=None):
     if 'dump_filter' in query:
         return query.pop('dump_filter'), query
     if command not in ('dump', 'show'):
-        return RequestProcessor(), query
+        return RequestProcessor(parameters=parameters), query
     new_query = {}
     if 'family' in query:
         new_query['family'] = query.pop('family')
@@ -134,7 +134,7 @@ def get_dump_filter(mode, command, query):
         query = query['match']
     if callable(query):
         return query, {}
-    dump_filter = RequestProcessor(context=query, prime=query)
+    dump_filter = RequestProcessor(context=query, prime=query, parameters=parameters)
     for rf in query.pop(
         'dump_filter', get_default_request_filters(mode, command)
     ):
@@ -2434,24 +2434,21 @@ class RTNL_API:
             'dump': (RTM_GETROUTE, 'dump'),
         }
         msg = rtmsg()
-        # table is mandatory without strict_check; by default == 254
-        # if table is not defined in kwarg, save it there
-        # also for nla_attr. Do not set it in strict_check, use
-        # NLA instead
-        #
-        # begin
-        #   FIXME: move this block to the request processor
-        if not self.status['strict_check']:
-            table = kwarg.get('table', 254)
-            msg['table'] = table if table <= 255 else 252
-        # end
-        dump_filter, kwarg = get_dump_filter('route', command, kwarg)
+        parameters = {'strict_check': self.status['strict_check']}
+        dump_filter, kwarg = get_dump_filter(
+            'route',
+            command,
+            kwarg,
+            parameters,
+        )
+
         arguments = get_arguments_processor(
             'route',
             command,
             kwarg,
-            {'strict_check': self.status['strict_check']},
+            parameters
         )
+
         request = NetlinkRequest(
             self, msg, command, command_map, dump_filter, arguments
         )

--- a/pyroute2/netlink/nlsocket.py
+++ b/pyroute2/netlink/nlsocket.py
@@ -121,6 +121,7 @@ from pyroute2.netlink.core import (
 )
 from pyroute2.netlink.exceptions import ChaoticException, NetlinkError
 from pyroute2.netlink.marshal import Marshal
+from pyroute2.netlink.rt_files import NlProtosFile
 from pyroute2.requests.main import RequestFilter
 
 log = logging.getLogger(__name__)
@@ -235,6 +236,10 @@ class AsyncNetlinkSocket(AsyncCoreSocket):
         use_event_loop=None,
         telemetry=None,
     ):
+
+        if isinstance(family, str):
+            family = NlProtosFile().get_rt_id(family)
+
         # 8<-----------------------------------------
         self.spec = NetlinkSocketSpec(
             NetlinkConfig(

--- a/pyroute2/netlink/rt_files.py
+++ b/pyroute2/netlink/rt_files.py
@@ -52,6 +52,13 @@ class IPRouteRtFile:
 
                     if rt_id_as_str.startswith("0x"):
                         rt_id = int(rt_id_as_str[2:], 16)
+                    elif ':' in rt_id_as_str:
+                        # tc handle as class_id string
+                        (major, minor) = [
+                            int(x if x else '0', 16)
+                            for x in rt_id_as_str.split(':')
+                        ]
+                        rt_id = (major << 16) | minor
                     else:
                         rt_id = int(rt_id_as_str)
 

--- a/pyroute2/netlink/rt_files.py
+++ b/pyroute2/netlink/rt_files.py
@@ -7,6 +7,7 @@ this module is an helper for all files
 from pathlib import Path
 from dataclasses import dataclass
 from dataclasses import field
+from dataclasses import fields
 
 
 @dataclass(slots=True)
@@ -21,6 +22,15 @@ class IPRouteRtFile:
 
     def __post_init__(self):
         self.load_files()
+
+    @classmethod
+    def get_rt_filename(cls):
+        """Helper to get filename when dataclass is not instancied
+        """
+        for rt_field in fields(cls):
+            if rt_field.name == 'filename':
+                return rt_field.default
+        raise KeyError(f"no filename in {cls}")
 
     def _iter_files(self, filepath):
         d_folder = Path(f'{filepath}.d')

--- a/pyroute2/netlink/rt_files.py
+++ b/pyroute2/netlink/rt_files.py
@@ -1,0 +1,155 @@
+"""Rt files parser
+
+iproute2 got lot of "map" files, called rt_xxx for most of them,
+this module is an helper for all files
+"""
+
+from pathlib import Path
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass(slots=True)
+class IPRouteRtFile:
+    filename: str
+
+    id2name: dict[int, str] = field(default_factory=dict)
+    name2id: dict[str, int] = field(default_factory=dict)
+
+    # like iproute2 stop at first existing directory
+    DIRECTORIES = (Path("/etc/iproute2/"), Path("/usr/share/iproute2/"))
+
+    def __post_init__(self):
+        self.load_files()
+
+    def _iter_files(self, filepath):
+        d_folder = Path(f'{filepath}.d')
+        if filepath.exists():
+            yield filepath
+        if d_folder.exists():
+            yield from (p for p in d_folder.iterdir() if p.suffix == '.conf')
+
+    def iter_files(self):
+        next_folder = True
+        for folder in self.DIRECTORIES:
+            for filepath in self._iter_files(folder / self.filename):
+                next_folder = False
+                yield filepath
+            if not next_folder:
+                return
+
+    def load_files(self):
+        self.id2name = {}
+        self.name2id = {}
+
+        for filename in self.iter_files():
+            with filename.open(encoding='utf-8') as fp:
+                for line in fp.readlines():
+                    line = line.strip()
+                    if not line or line[0] == '#':
+                        continue
+                    rt_id_as_str, rt_name = line.split()
+
+                    if rt_id_as_str.startswith("0x"):
+                        rt_id = int(rt_id_as_str[2:], 16)
+                    else:
+                        rt_id = int(rt_id_as_str)
+
+                    if rt_id in self.id2name:
+                        continue  # Accept only one rt_name by rt_id
+                    self.id2name[rt_id] = rt_name
+                    self.name2id[rt_name] = rt_id
+
+    def get_rt_id(self, rt_name: str | int, default: int | None = None) -> int | None:
+        """ Return id from the name.
+        if rt_name is an int or digits() return it as int
+        """
+        if isinstance(rt_name, int):
+            return rt_name
+        if rt_name.isdigit():
+            return int(rt_name)
+        if default is None:
+            return self.name2id[rt_name]
+        return self.name2id.get(rt_name, default)
+        
+    def get_rt_name(self, rt_id: str | int, default: str | None = None) -> str | None:
+        """ Return name from the id.
+        name not found return id as str
+        if the id is already a string return it
+        """
+        if isinstance(rt_id, str):
+            return rt_id
+        if default is None:
+            return self.id2name.get(rt_id, rt_id)
+        return self.id2name.get(rt_id, default)
+
+    def __iter__(self):
+        yield from self.id2name.items()
+
+
+@dataclass(slots=True)
+class EmatchMapFile(IPRouteRtFile):
+    filename: str = 'ematch_map'
+
+
+@dataclass(slots=True)
+class NlProtosFile(IPRouteRtFile):
+    filename: str = 'nl_protos'
+
+
+@dataclass(slots=True)
+class RtAddrProtosFile(IPRouteRtFile):
+    filename: str = 'rt_addrprotos'
+
+
+@dataclass(slots=True)
+class RtDsfieldFile(IPRouteRtFile):
+    filename: str = 'rt_dsfield'
+
+
+@dataclass(slots=True)
+class RtGroupFile(IPRouteRtFile):
+    filename: str = 'rt_group'
+
+
+@dataclass(slots=True)
+class RtProtosFile(IPRouteRtFile):
+    filename: str = 'rt_protos'
+
+
+@dataclass(slots=True)
+class RtRealmsFile(IPRouteRtFile):
+    filename: str = 'rt_realms'
+
+
+@dataclass(slots=True)
+class RtScopesFile(IPRouteRtFile):
+    filename: str = 'rt_scopes'
+
+
+@dataclass(slots=True)
+class RtTablesFile(IPRouteRtFile):
+    filename: str = 'rt_tables'
+
+
+@dataclass(slots=True)
+class TcClsFile(IPRouteRtFile):
+    filename: str = 'tc_cls'
+
+
+def main(cls_list):
+    for cls in cls_list.values():
+        try:
+            assert issubclass(cls, IPRouteRtFile) and not cls is IPRouteRtFile
+        except (TypeError, AssertionError):
+            continue
+
+        cls = cls()
+        print(f"====  Show rt maps for: {cls.filename} ===")
+        print("get_rt_id('default') ==", cls.get_rt_id("default", "pas trouvé"))
+        for id, name in cls:
+            print(f"{id} {name}")
+
+
+if __name__ == "__main__":
+    main(locals())

--- a/pyroute2/netlink/rtnl/ifaddrmsg.py
+++ b/pyroute2/netlink/rtnl/ifaddrmsg.py
@@ -73,6 +73,9 @@ class ifaddrmsg(nlmsg):
         ('IFA_CACHEINFO', 'cacheinfo'),
         ('IFA_MULTICAST', 'ipaddr'),
         ('IFA_FLAGS', 'uint32'),
+        ('IFA_RT_PRIORITY', 'uint32'),
+        ('IFA_TARGET_NETNSID', 'asciiz'),
+        ('IFA_PROTO', 'uint8'),
     )
 
     class cacheinfo(nla):

--- a/pyroute2/netlink/rtnl/tcmsg/common_ematch.py
+++ b/pyroute2/netlink/rtnl/tcmsg/common_ematch.py
@@ -1,3 +1,4 @@
+from pyroute2.netlink.rt_files import EmatchMapFile
 from pyroute2.netlink.rtnl.tcmsg import em_cmp, em_ipset, em_meta
 
 plugins = {
@@ -81,7 +82,10 @@ def get_tcf_ematches(kwarg):
         cur_match = kwarg['match'][i]
 
         # Translate string kind into numeric kind
-        kind = plugins_translate[cur_match['kind']]
+        try:
+            kind = plugins_translate[cur_match['kind']]
+        except KeyError:
+            kind = EmatchMapFile().get_rt_id(cur_match['kind'])
         match['kind'] = kind
         data = plugins[kind].data()
         data.setvalue(cur_match)

--- a/pyroute2/requests/address.py
+++ b/pyroute2/requests/address.py
@@ -2,6 +2,7 @@ import ipaddress
 from socket import AF_INET, AF_INET6
 
 from pyroute2.common import dqn2int, get_address_family, getbroadcast
+from pyroute2.netlink.rt_files import RtAddrProtosFile
 
 from .common import Index, IPRouteFilter, NLAKeyTransform
 
@@ -68,6 +69,11 @@ class AddressIPRouteFilter(IPRouteFilter):
                 cacheinfo[f'ifa_{i}'] = context.get(i, pow(2, 32) - 1)
             return {'cacheinfo': cacheinfo}
         return {}
+
+    def set_proto(self, context, value):
+        if isinstance(value, str):
+            value = RtAddrProtosFile().get_rt_id(value)
+        return {'proto': value}
 
     def set_broadcast(self, context, value):
         ret = {}

--- a/pyroute2/requests/link.py
+++ b/pyroute2/requests/link.py
@@ -1,5 +1,6 @@
 from pyroute2.netlink.rtnl.ifinfmsg import IFF_NOARP, IFF_UP, ifinfmsg
 from pyroute2.netlink.rtnl.ifinfmsg.plugins.vlan import flags as vlan_flags
+from pyroute2.netlink.rt_files import RtGroupFile
 
 from .common import Index, IPRouteFilter, NLAKeyTransform
 
@@ -92,6 +93,11 @@ class LinkIPRouteFilter(IPRouteFilter):
             ret['flags'] = (context.get('flags', 0) or 0) | IFF_NOARP
         ret['change'] = (context.get('change', 0) or 0) | IFF_NOARP
         return ret
+
+    def set_group(self, context, value):
+        if isinstance(value, str):
+            value = RtGroupFile().get_rt_id(value)
+        return {'group': value}
 
     def finalize(self, context):
         # set interface type specific attributes

--- a/pyroute2/requests/main.py
+++ b/pyroute2/requests/main.py
@@ -18,10 +18,10 @@ class RequestProcessor(dict):
     combined = None
     parameters = None
 
-    def __init__(self, context=None, prime=None):
+    def __init__(self, context=None, prime=None, parameters=None):
         self.reset_filters()
         self.reset_mark()
-        self.parameters = {}
+        self.parameters = dict(parameters) if parameters else {}
         prime = {} if prime is None else prime
         self.context = (
             context if isinstance(context, (dict, weakref.ProxyType)) else {}
@@ -102,7 +102,12 @@ class RequestProcessor(dict):
                 if setter is not None:
                     if ret is None:
                         ret = {}
-                    ret.update(setter(ChainMap(self.combined, ret), v))
+                    ret.update(setter(ChainMap(
+                        self.combined,
+                        ret,
+                        {'_parameters': self.parameters}
+                    ), v))
+
             if ret is not None:
                 job = ret
 

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -1,6 +1,7 @@
 from socket import AF_INET, AF_INET6
 
 from pyroute2.common import AF_MPLS
+from pyroute2.netlink.rt_files import RtDsfieldFile
 from pyroute2.netlink.rt_files import RtScopesFile
 from pyroute2.netlink.rt_files import RtTablesFile
 from pyroute2.netlink.rtnl import encap_type, rt_proto, rt_scope, rt_type
@@ -110,6 +111,11 @@ class RouteFieldFilter(IPTargets, NLAKeyTransform):
             if value > 255:
                 value = 252
         return {"table": value}
+
+    def set_tos(self, context, value):
+        if isinstance(value, str):
+            value = RtDsfieldFile().get_rt_id(value, 0)
+        return {"tos": value}
 
 
 class RouteIPRouteFilter(IPRouteFilter):

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -1,6 +1,7 @@
 from socket import AF_INET, AF_INET6
 
 from pyroute2.common import AF_MPLS
+from pyroute2.netlink.rt_files import RtScopesFile
 from pyroute2.netlink.rt_files import RtTablesFile
 from pyroute2.netlink.rtnl import encap_type, rt_proto, rt_scope, rt_type
 from pyroute2.netlink.rtnl.rtmsg import IP6_RT_PRIO_USER, LWTUNNEL_ENCAP_MPLS
@@ -79,7 +80,11 @@ class RouteFieldFilter(IPTargets, NLAKeyTransform):
 
     def set_scope(self, context, value):
         if isinstance(value, str):
-            return {'scope': rt_scope[value]}
+            try:
+                value = rt_scope[value]
+            except KeyError:
+                # lookup with rt_scopes* files
+                value = RtScopesFile().get_rt_id(value)
         return {'scope': value}
 
     def set_proto(self, context, value):

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -3,6 +3,7 @@ from socket import AF_INET, AF_INET6
 from pyroute2.common import AF_MPLS
 from pyroute2.netlink.rt_files import RtDsfieldFile
 from pyroute2.netlink.rt_files import RtProtosFile
+from pyroute2.netlink.rt_files import RtRealmsFile
 from pyroute2.netlink.rt_files import RtScopesFile
 from pyroute2.netlink.rt_files import RtTablesFile
 from pyroute2.netlink.rtnl import encap_type, rt_proto, rt_scope, rt_type
@@ -132,6 +133,13 @@ class RouteIPRouteFilter(IPRouteFilter):
                 return 0
             return table if 0 < table < 255 else 254
         return table
+
+    def set_flow(self, context, value):
+        if isinstance(value, str):
+            value = RtRealmsFile().get_rt_id(value)
+        return {"flow": value}
+
+    set_realms = set_flow
 
     def set_metrics(self, context, value):
         if value and 'attrs' not in value:

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -96,6 +96,11 @@ class RouteFieldFilter(IPTargets, NLAKeyTransform):
             return {'type': rt_type[value]}
         return {'type': value}
 
+    def set_table(self, context, value):
+        if not context["_parameters"]['strict_check']:
+            return {'table': value if value <= 255 else 252}
+        return {}
+
 
 class RouteIPRouteFilter(IPRouteFilter):
 

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -1,6 +1,7 @@
 from socket import AF_INET, AF_INET6
 
 from pyroute2.common import AF_MPLS
+from pyroute2.netlink.rt_files import RtTablesFile
 from pyroute2.netlink.rtnl import encap_type, rt_proto, rt_scope, rt_type
 from pyroute2.netlink.rtnl.rtmsg import IP6_RT_PRIO_USER, LWTUNNEL_ENCAP_MPLS
 from pyroute2.netlink.rtnl.rtmsg import nh as nh_header
@@ -97,9 +98,13 @@ class RouteFieldFilter(IPTargets, NLAKeyTransform):
         return {'type': value}
 
     def set_table(self, context, value):
+        if isinstance(value, str):
+            value = RtTablesFile().get_rt_id(value, 0)
+
         if not context["_parameters"]['strict_check']:
-            return {'table': value if value <= 255 else 252}
-        return {}
+            if value > 255:
+                value = 252
+        return {"table": value}
 
 
 class RouteIPRouteFilter(IPRouteFilter):

--- a/pyroute2/requests/route.py
+++ b/pyroute2/requests/route.py
@@ -2,6 +2,7 @@ from socket import AF_INET, AF_INET6
 
 from pyroute2.common import AF_MPLS
 from pyroute2.netlink.rt_files import RtDsfieldFile
+from pyroute2.netlink.rt_files import RtProtosFile
 from pyroute2.netlink.rt_files import RtScopesFile
 from pyroute2.netlink.rt_files import RtTablesFile
 from pyroute2.netlink.rtnl import encap_type, rt_proto, rt_scope, rt_type
@@ -90,7 +91,11 @@ class RouteFieldFilter(IPTargets, NLAKeyTransform):
 
     def set_proto(self, context, value):
         if isinstance(value, str):
-            return {'proto': rt_proto[value]}
+            try:
+                value = rt_proto[value]
+            except KeyError:
+                # lookup with rt_proto* files
+                value = RtProtosFile().get_rt_id(value)
         return {'proto': value}
 
     def set_encap_type(self, context, value):

--- a/pyroute2/requests/tc.py
+++ b/pyroute2/requests/tc.py
@@ -1,5 +1,6 @@
 from pyroute2.netlink.rtnl import TC_H_ROOT
 from pyroute2.netlink.rtnl.tcmsg import plugins as tc_plugins
+from pyroute2.netlink.rt_files import TcClsFile
 
 from .common import IPRouteFilter
 
@@ -7,10 +8,13 @@ from .common import IPRouteFilter
 class TcRequestFilter:
     def transform_handle(self, key, context, handle):
         if isinstance(handle, str):
-            (major, minor) = [
-                int(x if x else '0', 16) for x in handle.split(':')
-            ]
-            handle = (major << 8 * 2) | minor
+            if ':' not in handle:
+                handle = TcClsFile().get_rt_id(handle)
+            else:
+                (major, minor) = [
+                    int(x if x else '0', 16) for x in handle.split(':')
+                ]
+                handle = (major << 8 * 2) | minor
         return {key: handle}
 
     def set_handle(self, context, value):

--- a/tests/test_linux/conftest.py
+++ b/tests/test_linux/conftest.py
@@ -7,6 +7,7 @@ from fixtures.dhcp_servers.mock import mock_dhcp_server  # noqa: F401
 from fixtures.dhcp_servers.udhcpd import udhcpd, udhcpd_config  # noqa: F401
 from fixtures.interfaces import dhcp_range, veth_pair  # noqa: F401
 from fixtures.pcap_files import pcap  # noqa: F401
+from fixtures.rt_file import CreateRtFile  # noqa: F401
 from pr2test.context_manager import NDBContextManager, SpecContextManager
 from utils import require_user
 
@@ -71,3 +72,11 @@ def wiset_sock(request):
         with IPSet() as sock:
             yield sock
         assert before_count == COUNT['count']
+
+
+@pytest.fixture
+def fake_rt_file(tmpdir):
+    '''
+    A simple fixture with only some variables set
+    '''
+    yield CreateRtFile(tmpdir)

--- a/tests/test_linux/fixtures/rt_file.py
+++ b/tests/test_linux/fixtures/rt_file.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from pyroute2.netlink import rt_files
+
+
+class CreateRtFile:
+
+    def __init__(self, tmpdir):
+        self.tmpdir = tmpdir
+        rt_files.IPRouteRtFile.DIRECTORIES = [Path(self.tmpdir)]
+
+    def create(self, rt_file, file_as_dict):
+        with (self.tmpdir / rt_file.get_rt_filename()).open("w+") as fp:
+            for key, value in file_as_dict.items():
+                fp.write(f"{key} {value}\n")

--- a/tests/test_linux/test_ipr/test_route.py
+++ b/tests/test_linux/test_ipr/test_route.py
@@ -10,6 +10,7 @@ from utils import require_kernel
 from pyroute2 import IPRoute, NetlinkError
 from pyroute2.common import AF_MPLS
 from pyroute2.netlink.rtnl.rtmsg import RTNH_F_ONLINK
+from pyroute2.netlink.rt_files import RtTablesFile
 
 pytestmark = [require_root()]
 
@@ -453,3 +454,18 @@ def test_flush_routes(context):
         time.sleep(0.1)
     else:
         raise Exception('route table not flushed')
+
+
+def test_route_with_rt_file(context, fake_rt_file):
+    fake_rt_file.create(RtTablesFile, {
+        "254": "my_table"
+    })
+
+    if not context.ipr.get_default_routes(table="my_table"):
+        pytest.skip('no default IPv4 routes')
+    require_kernel(4, 20)
+
+    with IPRoute(strict_check=True) as ip:
+        rts = list(ip.get_routes(family=socket.AF_INET, dst='8.8.8.8', table="my_table"))
+        assert len(rts) > 0
+        assert RtTablesFile().get_rt_name(rts[0].get("RTA_TABLE")) == "my_table"


### PR DESCRIPTION
Hello @svinota, I implement management of all rt_file of iproute2 [Found on their repository](https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/tree/etc/iproute2)

You can easily replace int value to an str like this:

```python
from pyroute2 import IPRoute
ipr.route("show", table="main")
ipr.route("show", table="local")
ipr.link("dump", group="default")
...
```