### PR TITLE
Add Support for Geneve innerprotoinherit

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/plugins/geneve.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/plugins/geneve.py
@@ -17,6 +17,7 @@ class geneve(nla):
         ('IFLA_GENEVE_LABEL', 'be32'),
         ('IFLA_GENEVE_TTL_INHERIT', 'uint8'),
         ('IFLA_GENEVE_DF', 'df'),
+        ('IFLA_GENEVE_INNER_PROTO_INHERIT', 'flag'),
     )
 
     class df(nlmsg_atoms.uint16):


### PR DESCRIPTION
## Summary
This change addresses https://github.com/svinota/pyroute2/issues/1394 by adding support for the `innerprotoinherit` flag for Geneve interfaces.

## Testing
### Verified Flag Behavior
Created a network interface with

```
from pyroute2 import IPRoute

ip = IPRoute()
ip.link("add",
        ifname="g0",
        kind="geneve",
        geneve_id=1000,
        geneve_remote="172.30.16.26",
        geneve_inner_proto_inherit=1)

idx = ip.link_lookup(ifname="g0")[0]
ip.link("set", index=idx, state="up")
```

Before this change, the `innerprotoinherit` flag is dropped: 
```
ip -d link show
g0: <NOARP,UP,LOWER_UP> mtu 8951 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/none  promiscuity 0 allmulti 0 minmtu 68 maxmtu 65485 
    geneve id 1000 remote 172.30.16.26 ttl auto dstport 6081 noudpcsum udp6zerocsumrx addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
```

After this change, the `innerprotoinherit` flag is **not** dropped:
```
g0: <NOARP,UP,LOWER_UP> mtu 8951 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/none  promiscuity 0 allmulti 0 minmtu 68 maxmtu 65485 
    geneve id 1000 remote 172.30.16.26 ttl auto dstport 6081 noudpcsum udp6zerocsumrx innerprotoinherit addrgenmode random numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
```

### Existing Tests
- `sudo make test` passes
- `sudo make format` passes