### PR TITLE
ifinfmsg: add IFLA_ALLMULTI flag

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/__init__.py
@@ -531,6 +531,7 @@ class ifinfbase(object):
         ('IFLA_GRO_MAX_SIZE', 'uint32'),
         ('IFLA_TSO_MAX_SIZE', 'uint32'),
         ('IFLA_TSO_MAX_SEGS', 'uint32'),
+        ('IFLA_ALLMULTI', 'uint32'),
     )
 
     @staticmethod


### PR DESCRIPTION
It has been added some years ago in kernel

A very small update. Some other attributes are missing, but the next one is IFLA_DEVLINK_PORT and is nested.