### PR TITLE
ci: propagate python version from make to nox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 #   The pyroute2 project is dual licensed, see README.license.md for details
 #
 #
+ifneq ($(strip $(python)),)
+	forcePython := --force-python ${python}
+else
+	forcePython :=
+endif
 checkModules ?= ensurepip
 python ?= $(shell util/find_python.sh ${checkModules} )
 platform := $(shell uname -s)
@@ -24,7 +29,7 @@ define nox
 					pip install nox;\
 				};\
 		};\
-		nox $(1) -- '${noxconfig}';\
+		nox ${forcePython} $(1) -- '${noxconfig}';\
 	}
 endef
 

--- a/util/find_python.sh
+++ b/util/find_python.sh
@@ -9,7 +9,7 @@ function list_pythons() {
     #
     # List all python binaries/shims/links in a directory $1
     #
-    ls -1 $1/python* 2>/dev/null | grep -E 'python[0-9.]+$'
+    ls -1 $1/python* 2>/dev/null | grep -E 'python[0-9.]+$' | sed 's!.*/!!'
 }
 
 function check_valid_python() {


### PR DESCRIPTION
Fix `make ... python=pythonX.Y` to propagate the version to nox as well.