### PR TITLE
process: add an option for caller using custom handlers

### DIFF
--- a/pyroute2/config/__init__.py
+++ b/pyroute2/config/__init__.py
@@ -79,6 +79,8 @@ db_transaction_limit = 1
 cache_expire = 60
 telemetry = None
 child_process_mode = 'fork'
+# Disable signal in 'mp' mode of child_process_mode
+disable_mp_signal = False
 force_gc = False
 signal_stop_remote = None
 if hasattr(signal, 'SIGUSR1'):

--- a/pyroute2/process.py
+++ b/pyroute2/process.py
@@ -41,6 +41,9 @@ def wrapper(
     If process doesn't response in time, it will get killed.
     '''
     gc.disable()
+    if config.disable_mp_signal:
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
     payload: bytes = b''
     ret_data: bytes = b''
     fds: list[int] = []


### PR DESCRIPTION
Hello,

We are running pyroute2 in python processes using custom signal handlers, and not python defaults. It looks like running a process in "mp" mode are inheriting handlers, and this can be very confusing for the main daemon.

An option is perhaps not the best choice, but my goal was to not break anything outside of our use case.