### PR TITLE
ipmock: fix ambiguity with MockRoute's type and route_type params

### DIFF
--- a/pyroute2/iproute/ipmock.py
+++ b/pyroute2/iproute/ipmock.py
@@ -379,7 +379,6 @@ class MockRoute:
         self.route_type = route_type
         self.priority = kwarg.get('priority', 0)
         self.tos = kwarg.get('tos', 0)
-        self._type = kwarg.get('type', 2)
 
     def update_from_msg(self, msg):
         [
@@ -411,7 +410,7 @@ class MockRoute:
             'table': self.table if self.table <= 255 else 252,
             'proto': self.proto,
             'scope': self.scope,
-            'type': self._type,
+            'type': self.route_type,
             'flags': 0,
             'attrs': [('RTA_TABLE', self.table), ('RTA_OIF', self.oif)],
             'header': {


### PR DESCRIPTION
In commit 43206d9b022b137d349e4fa5db167ae261c027ba, while adding support for routes priority, we introduced a new parameter for `MockRoute` called `type`.

However, there was already a parameter called `route_type` which seemingly intended to serve the same purpose. That parameter was used in mock presets, but unfortunately wasn't honored when calling the `.export()` function.

Before this patch the situation was that we had two ambiguous types:

 * `route_type`, which is used in mock presets but isn't honored when calling `.export()`. It has a default value of  `RTN_UNICAST`.
 * `type`, which is not used in mock presets but would otherwise get honored when calling `.export()`. It has a default value of `RTN_LOCAL`.

Fixed by dropping the redundant `type` parameter and using the value of `route_type` when calling `.export()`. This means the default value for the route type is now `RTN_UNICAST`, which sounds acceptable.