### PR TITLE
dhcp: add support for encoding & decoding option 118 (subnet selection)

### DIFF
--- a/pyroute2/dhcp/dhcp4msg.py
+++ b/pyroute2/dhcp/dhcp4msg.py
@@ -102,6 +102,7 @@ class dhcp4msg(dhcpmsg):
         (Option.REBINDING_TIME, 'sbe32'),
         (Option.VENDOR_ID, 'string'),
         (Option.CLIENT_ID, 'client_id'),
+        (Option.SUBNET_SELECTION, 'ip4addr'),
         (Option.END, 'none'),
     )
 

--- a/tests/test_linux/test_dhcp/test_encode.py
+++ b/tests/test_linux/test_dhcp/test_encode.py
@@ -19,6 +19,7 @@ from pyroute2.dhcp.enums import dhcp
         ('perform_mask_discovery', True),
         ('tcp_keepalive_garbage', False),
         ('host_name', [104, 97, 153, 104, 97]),
+        ('subnet_selection', '10.0.0.0'),
     ),
 )
 def test_encode_decode_options(option_name: str, option_value: Any):


### PR DESCRIPTION
Hi, it's me again !

I've been working on a reproducer for an obscure dnsmasq issue, and I needed to be able to send the subnet selection option. It is silently discarded at the moment since there is no mapping for it in `dhcp4msg.options`.

It's a very small MR, i just added an tested this single option.

(see [RFC3011](https://www.rfc-editor.org/rfc/rfc3011.html) for details)