### PR TITLE
Add sunway 64bit syscall number

### DIFF
--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -78,6 +78,7 @@ __NR = {
     's390': {'64bit': 339},
     'loongarch64': {'64bit': 268},
     'risc': {'64bit': 268},
+    'sw_6': {'64bit': 501}
 }
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 


### PR DESCRIPTION
Sunway is a computer CPU with RISC instruction set (see https://en.wikipedia.org/wiki/Sunway_(processor) for more information).

Its kernel source is in openEuler repo
(https://gitee.com/openeuler/kernel/blob/openEuler-22.03-LTS/arch/sw_64/kernel/syscalls/syscall.tbl#L511)