### PR TITLE
Improve cleanup of DHCP server detector tasks

### DIFF
--- a/pyroute2/dhcp/dhcp4socket.py
+++ b/pyroute2/dhcp/dhcp4socket.py
@@ -7,7 +7,6 @@ IPv4 DHCP socket
 import asyncio
 import logging
 import socket
-from asyncio.exceptions import CancelledError
 from typing import Optional
 
 from pyroute2.compat import ETHERTYPE_IP
@@ -197,17 +196,14 @@ class AsyncDHCP4Socket(AsyncRawSocket):
             )
 
         '''
-        try:
-            msg: Optional[ReceivedDHCPMessage] = None
-            while not msg:
-                raw = await self.loop.sock_recv(self, 4096)
-                try:
-                    msg = self._decode_msg(raw)
-                except ValueError as err:
-                    LOG.error('%s', err)
-            return msg
-        except CancelledError:
-            pass
+        msg: Optional[ReceivedDHCPMessage] = None
+        while not msg:
+            raw = await self.loop.sock_recv(self, 4096)
+            try:
+                msg = self._decode_msg(raw)
+            except ValueError as err:
+                LOG.error('%s', err)
+        return msg
 
     @classmethod
     def _decode_msg(cls, data: bytes) -> ReceivedDHCPMessage:

--- a/pyroute2/dhcp/dhcp4socket.py
+++ b/pyroute2/dhcp/dhcp4socket.py
@@ -7,6 +7,7 @@ IPv4 DHCP socket
 import asyncio
 import logging
 import socket
+from asyncio.exceptions import CancelledError
 from typing import Optional
 
 from pyroute2.compat import ETHERTYPE_IP
@@ -196,14 +197,17 @@ class AsyncDHCP4Socket(AsyncRawSocket):
             )
 
         '''
-        msg: Optional[ReceivedDHCPMessage] = None
-        while not msg:
-            raw = await self.loop.sock_recv(self, 4096)
-            try:
-                msg = self._decode_msg(raw)
-            except ValueError as err:
-                LOG.error('%s', err)
-        return msg
+        try:
+            msg: Optional[ReceivedDHCPMessage] = None
+            while not msg:
+                raw = await self.loop.sock_recv(self, 4096)
+                try:
+                    msg = self._decode_msg(raw)
+                except ValueError as err:
+                    LOG.error('%s', err)
+            return msg
+        except CancelledError:
+            pass
 
     @classmethod
     def _decode_msg(cls, data: bytes) -> ReceivedDHCPMessage:

--- a/pyroute2/dhcp/server_detector.py
+++ b/pyroute2/dhcp/server_detector.py
@@ -95,7 +95,10 @@ class DHCPServerDetector:
                     # if get is still pending, that means send_task is over
                     if get_next_msg in pending:
                         get_next_msg.cancel()
-                        await get_next_msg
+                        try:
+                            await get_next_msg
+                        except CancelledError:
+                            pass
                         continue
                     # we have a new message
                     next_msg = await get_next_msg
@@ -113,7 +116,10 @@ class DHCPServerDetector:
                     send_task.cancel()
                     await send_task
                     get_next_msg.cancel()
-                    await get_next_msg
+                    try:
+                        await get_next_msg
+                    except CancelledError:
+                        pass
                     break
             else:
                 await send_task

--- a/pyroute2/dhcp/server_detector.py
+++ b/pyroute2/dhcp/server_detector.py
@@ -69,7 +69,7 @@ class DHCPServerDetector:
                 await sock.put(msg)
                 await asyncio.sleep(self.interval)
             except CancelledError:
-                pass
+                break
 
     async def _get_offers(self, interface: str):
         '''Send DISCOVERs and wait for responses on an interface.'''

--- a/pyroute2/dhcp/server_detector.py
+++ b/pyroute2/dhcp/server_detector.py
@@ -62,14 +62,14 @@ class DHCPServerDetector:
 
     async def _send_forever(self, sock: AsyncDHCP4Socket):
         '''Send the `DISCOVER` message at `interval` until cancelled.'''
-        try:
-            msg = self.discover_messages[sock.ifname]
-            while True:
-                LOG.info('[%s] -> %s', sock.ifname, msg)
+        msg = self.discover_messages[sock.ifname]
+        while True:
+            LOG.info('[%s] -> %s', sock.ifname, msg)
+            try:
                 await sock.put(msg)
                 await asyncio.sleep(self.interval)
-        except CancelledError:
-            pass
+            except CancelledError:
+                pass
 
     async def _get_offers(self, interface: str):
         '''Send DISCOVERs and wait for responses on an interface.'''


### PR DESCRIPTION
I'm using the DHCPServerDetector directly to help me with provisioning commercial off-the-shelf routers, it's a great help, so thanks for the implementation. However, I noticed using detect_servers() was rather leaky with regards to cleaning up certain async tasks, presumably because the main usage is as a CLI tool, where it matters less. But because the leftover tasks were cluttering up my logs with various error messages, here are two commits to improve the usage of detect_servers() through plain Python.

I'm not too familiar with the development side of this project, so if I missed something important, do let me know and I'll happily correct whatever is needed.