### PR TITLE
netlink/rt_files: Fix group filename

### DIFF
--- a/pyroute2/netlink/rt_files.py
+++ b/pyroute2/netlink/rt_files.py
@@ -127,8 +127,8 @@ class RtDsfieldFile(IPRouteRtFile):
 
 
 @dataclass
-class RtGroupFile(IPRouteRtFile):
-    filename: str = 'rt_group'
+class GroupFile(IPRouteRtFile):
+    filename: str = 'group'
 
 
 @dataclass

--- a/pyroute2/requests/link.py
+++ b/pyroute2/requests/link.py
@@ -1,4 +1,4 @@
-from pyroute2.netlink.rt_files import RtGroupFile
+from pyroute2.netlink.rt_files import GroupFile
 from pyroute2.netlink.rtnl.ifinfmsg import IFF_NOARP, IFF_UP, ifinfmsg
 from pyroute2.netlink.rtnl.ifinfmsg.plugins.vlan import flags as vlan_flags
 
@@ -96,7 +96,7 @@ class LinkIPRouteFilter(IPRouteFilter):
 
     def set_group(self, context, value):
         if isinstance(value, str):
-            value = RtGroupFile().get_rt_id(value)
+            value = GroupFile().get_rt_id(value)
         return {'group': value}
 
     def finalize(self, context):


### PR DESCRIPTION
A typo named the group file as `rt_group` instead of `group`