### PR TITLE
process: Use poll than select for using fd > 1024.

### DIFF
--- a/pyroute2/process.py
+++ b/pyroute2/process.py
@@ -120,8 +120,12 @@ class ChildProcess:
             raise RuntimeError('child process not started yet')
         if timeout == USE_DEFAULT_TIMEOUT:
             timeout = config.default_communicate_timeout
-        rl, _, _ = select.select([self.ctrl_r], [], [], timeout)
-        if not len(rl):
+
+        poll = select.poll()
+        poll.register(self.ctrl_r, select.POLLIN)
+        poll_results = poll.poll(timeout * 1000)  # convert to microseconds
+        poll.unregister(self.ctrl_r)
+        if not poll_results:
             # no data received within timeout
             # 1. the child process is killed
             # 2. the child process is stuck


### PR DESCRIPTION
Hello @svinota, we recently ran into a bug in one of our programs that uses a large number of file descriptors. It crashed with a "ValueError: filedescriptor out of range in select()" on pyroute2/process.py, we fixed it by switching to poll.

Thanks!