### PR TITLE
dhcp client: call UNBOUND hooks when receiving a NAK with an active lease

### DIFF
--- a/pyroute2/dhcp/client.py
+++ b/pyroute2/dhcp/client.py
@@ -493,6 +493,11 @@ class AsyncDHCPClient:
 
         Resets the client and starts looking for a new IP.
         '''
+        # If we get a NAK when rebooting, renewing, or rebinding,
+        # that means we have an active lease which is not valid anymore.
+        # In these cases, we have to run the UNBOUND trigger
+        if msg.xid.request_state != fsm.State.REQUESTING:
+            await self._run_hooks(trigger=Trigger.UNBOUND)
         await self.reset()
 
     @fsm.state_guard(fsm.State.SELECTING)

--- a/pyroute2/dhcp/hooks.py
+++ b/pyroute2/dhcp/hooks.py
@@ -19,7 +19,8 @@ class Trigger(StrEnum):
 
     # The client has obtained a new lease
     BOUND = auto()
-    # The client has voluntarily relinquished its lease
+    # The client has voluntarily relinquished its lease,
+    # or its current lease has been invalidated by a NAK
     UNBOUND = auto()
     # The client has renewed its lease after the renewal timer expired
     RENEWED = auto()


### PR DESCRIPTION
Hello, it's me again !

We've noticed an issue in production on our side, when the DHCP server would send a `NAK` while trying to renew our lease.

Of course, when this happens, according to the RFC, section 3.1

> If the client receives a DHCPNAK message, the client restarts the configuration process.

But in these cases, the client did not call any hook, which is an oversight on my part. That means we do not get a chance to perform actions when the server tells us our lease is invalid.

So I added a few lines of code which will call the relevant hook(s) when it happens.

I'll leave this PR as a draft while i check with the rest of the team that this behavior seems sensible, or whether we would need another hook trigger for this.

Thanks !