### PR TITLE
drop support for Python 3.9

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: Fedora
     strategy:
       matrix:
-        python: [python3.9, python3.13]
+        python: [python3.10, python3.13]
     steps:
       - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v5
@@ -81,7 +81,7 @@ jobs:
     runs-on: Fedora
     strategy:
       matrix:
-        python: [python3.9, python3.14]
+        python: [python3.10, python3.14]
     steps:
       - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v5
@@ -90,7 +90,7 @@ jobs:
     runs-on: Fedora
     strategy:
       matrix:
-        python: [python3.9, python3.14]
+        python: [python3.10, python3.14]
     steps:
       - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v5
@@ -117,7 +117,7 @@ jobs:
     runs-on: Fedora
     strategy:
       matrix:
-        python: [python3.9, python3.14]
+        python: [python3.10, python3.14]
     steps:
       - run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v5

--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ Using source, requires make and nox
 Requirements
 ------------
 
-Python >= 3.9
+Python >= 3.10
 
 Links
 -----

--- a/tests/test_linux/test_iwutil.py
+++ b/tests/test_linux/test_iwutil.py
@@ -1,5 +1,6 @@
 import collections
 import errno
+from types import NoneType
 from typing import Generator
 
 import pytest
@@ -8,12 +9,6 @@ from pr2test.marks import require_root
 from pyroute2 import IW, IPRoute
 from pyroute2.netlink.exceptions import NetlinkError
 from pyroute2.netlink.nl80211 import nl80211cmd
-
-# FIXME: should be fixed after dropping support for Python 3.9
-try:
-    from types import NoneType
-except ImportError:
-    NoneType = type(None)
 
 pytestmark = [require_root()]
 


### PR DESCRIPTION
Python 3.9 has reached its EOL, so remove it from the CI.

See also: https://devguide.python.org/versions/

Minimal supported Python version now is 3.10