### PR TITLE
vlan: add missing bridge_binding flag

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/plugins/vlan.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/plugins/vlan.py
@@ -1,6 +1,6 @@
 from pyroute2.netlink import nla
 
-flags = {'reorder_hdr': 0x1, 'gvrp': 0x2, 'loose_binding': 0x4, 'mvrp': 0x8}
+flags = {'reorder_hdr': 0x1, 'gvrp': 0x2, 'loose_binding': 0x4, 'mvrp': 0x8, 'bridge_binding': 0x10}
 
 
 class vlan(nla):


### PR DESCRIPTION
This adds the value for the missing `bridge_binding` flag in `IFA_VLAN_FLAGS`.

https://github.com/iproute2/iproute2/blob/v6.17.0/include/uapi/linux/if_vlan.h#L39