### PR TITLE
Fix DHCP client log level when receiving a message with an unexpected XID

### DIFF
--- a/pyroute2/dhcp/client.py
+++ b/pyroute2/dhcp/client.py
@@ -633,8 +633,13 @@ class AsyncDHCPClient:
         '''
         msg_type = dhcp.MessageType(msg.dhcp['options']['message_type'])
         LOG.info('Received %s', msg)
+        # It is normal to receive DHCP messages with an unexpected xid.
+        # A lot of DHCP messages are broadcast, we read them all,
+        # and they aren't all intended for us.
+        # However it can be useful to know when it's the case,
+        # hence the debug log.
         if not self.xid.matches(msg.xid):
-            LOG.error(
+            LOG.debug(
                 'Incorrect xid %s (expected %sX), discarding',
                 msg.xid,
                 hex(self.xid.random_part)[:-1],

--- a/tests/test_linux/test_dhcp/test_unit.py
+++ b/tests/test_linux/test_dhcp/test_unit.py
@@ -319,15 +319,18 @@ async def test_offer_wrong_xid(
     is a symlink to the one for test_requesting_timeout
     '''
     set_fixed_xid(0x98765432)
-    caplog.set_level('ERROR')
+    caplog.set_level('DEBUG')
     async with AsyncDHCPClient(client_config) as cli:
         await cli.bootstrap()
         await cli.wait_for_state(State.SELECTING, timeout=1)
         # wait a tiny bit for the offer to arrive
         await asyncio.sleep(0.5)
-    assert caplog.messages == [
-        'Incorrect xid 0xdd435a25 (expected 0x9876543X), discarding'
-    ]
+    assert (
+        caplog.messages.count(
+            'Incorrect xid 0xdd435a25 (expected 0x9876543X), discarding'
+        )
+        == 1
+    )
 
     assert len(mock_dhcp_server.decoded_requests) == 1
     discover = mock_dhcp_server.decoded_requests[0]


### PR DESCRIPTION
Hi, it's me once again, with a tiny PR ! Hope you've been doing well since the last time, and that 2026 will be a good year for you and pyroute2.

We've been using the DHCP client for a while now (nearly a year ! time passes so fast), and when it receives a message with an unexpected xid, it logs an error, which was fine during development but generates too much useless logs in production.

Since DHCP is mostly broadcasts, it is completely normal to receive messages with an unexpected xid; all messages aren't meant for us.

I left the log, because it is still useful when troubleshooting, but reduced its level from error to debug so we won't get spammed anymore.

Thanks in advance, and until my next PR, take care !