### PR TITLE
netlink: Support to read and write RTAX_CC_ALGO on route metrics

### DIFF
--- a/pyroute2/iproute/linux.py
+++ b/pyroute2/iproute/linux.py
@@ -2213,6 +2213,7 @@ class RTNL_API:
                 metrics={
                     "mtu": 1400,
                     "hoplimit": 16,
+                    "cc_algo": "cubic",
                 },
             )
 

--- a/pyroute2/ndb/objects/route.py
+++ b/pyroute2/ndb/objects/route.py
@@ -94,12 +94,13 @@ reflects route metrics like hop limit, mtu etc:
 
     # set up all metrics from a dictionary
     with ndb.routes['10.0.0.0/24'] as route:
-        route.set('metrics', {'mtu': 1500, 'hoplimit': 20})
+        route.set('metrics', {'mtu': 1500, 'hoplimit': 20, 'cc_algo': 'cubic'})
 
     # fix individual metrics
     with ndb.routes['10.0.0.0/24']['metrics'] as metrics:
         metrics.set('mtu', 1500)
         metrics.set('hoplimit', 20)
+        metrics.set('cc_algo', 'cubic')
 
 MPLS routes
 ===========

--- a/pyroute2/netlink/rtnl/rtmsg.py
+++ b/pyroute2/netlink/rtnl/rtmsg.py
@@ -703,6 +703,7 @@ class rtmsg_base(nlflags):
             ('RTAX_RTO_MIN', 'uint32'),
             ('RTAX_INITRWND', 'uint32'),
             ('RTAX_QUICKACK', 'uint32'),
+            ('RTAX_CC_ALGO', 'asciiz'),
         )
 
     @staticmethod

--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -89,7 +89,7 @@ MS_REC = 16384
 MS_SHARED = 1 << 20
 NETNS_RUN_DIR = '/var/run/netns'
 
-__saved_ns = []
+__saved_ns: list[int] = []
 __libc = None
 
 

--- a/tests/test_linux/test_ndb/test_routes.py
+++ b/tests/test_linux/test_ndb/test_routes.py
@@ -468,6 +468,29 @@ def test_metrics_set(context):
     )
 
 
+@pytest.mark.parametrize('context', test_matrix, indirect=True)
+def test_metrics_cc_algo_set(context):
+    index, ifname = context.default_interface
+    ifaddr = context.new_ipaddr
+    gateway = context.new_ipaddr
+    ipnet = str(context.ipnets[1].network)
+    # use reno for testing as it's availalbe on all kernels.
+    target = 'reno'
+
+    with context.ndb.interfaces[ifname] as dummy:
+        dummy.add_ip(address=ifaddr, prefixlen=24)
+        dummy.set(state='up')
+
+    route = context.ndb.routes.create(
+        dst=ipnet, dst_len=24, gateway=gateway, metrics={'cc_algo': target}
+    )
+    route.commit()
+
+    assert route_exists(
+        context.netns, match=partial(match_metrics, target, gateway)
+    )
+
+
 def _test_metrics_update(context, method):
     ifaddr = context.new_ipaddr
     gateway1 = context.new_ipaddr

--- a/tests/test_linux/test_ndb/test_routes.py
+++ b/tests/test_linux/test_ndb/test_routes.py
@@ -393,11 +393,11 @@ def test_same_multipath(context):
     assert route_exists(context.netns, match=match_multipath)
 
 
-def match_metrics(target, gateway, msg):
+def match_metrics(metric, target, gateway, msg):
     if msg.get_attr('RTA_GATEWAY') != gateway:
         return False
-    mtu = msg.get_attr('RTA_METRICS', rtmsg()).get_attr('RTAX_MTU', 0)
-    return mtu == target
+    value = msg.get_attr('RTA_METRICS', rtmsg()).get_attr(metric)
+    return value == target
 
 
 @pytest.mark.parametrize('context', test_matrix, indirect=True)
@@ -435,7 +435,7 @@ def test_same_metrics(context):
     # but lets double check
     assert address_exists(context.netns, ifname=ifname, address=ifaddr)
     assert route_exists(
-        context.netns, match=partial(match_metrics, target, gateway2)
+        context.netns, match=partial(match_metrics, 'RTAX_MTU', target, gateway2)
     )
 
 
@@ -464,7 +464,7 @@ def test_metrics_set(context):
 
     route.commit()
     assert route_exists(
-        context.netns, match=partial(match_metrics, target, gateway)
+        context.netns, match=partial(match_metrics, 'RTAX_MTU', target, gateway)
     )
 
 
@@ -487,7 +487,8 @@ def test_metrics_cc_algo_set(context):
     route.commit()
 
     assert route_exists(
-        context.netns, match=partial(match_metrics, target, gateway)
+        context.netns,
+        match=partial(match_metrics, 'RTAX_CC_ALGO', target, gateway),
     )
 
 

--- a/tests/test_linux/test_ndb/test_routes.py
+++ b/tests/test_linux/test_ndb/test_routes.py
@@ -435,7 +435,8 @@ def test_same_metrics(context):
     # but lets double check
     assert address_exists(context.netns, ifname=ifname, address=ifaddr)
     assert route_exists(
-        context.netns, match=partial(match_metrics, 'RTAX_MTU', target, gateway2)
+        context.netns,
+        match=partial(match_metrics, 'RTAX_MTU', target, gateway2),
     )
 
 
@@ -464,7 +465,8 @@ def test_metrics_set(context):
 
     route.commit()
     assert route_exists(
-        context.netns, match=partial(match_metrics, 'RTAX_MTU', target, gateway)
+        context.netns,
+        match=partial(match_metrics, 'RTAX_MTU', target, gateway),
     )
 
 

--- a/tests/test_unit/test_requests/test_route.py
+++ b/tests/test_unit/test_requests/test_route.py
@@ -144,3 +144,28 @@ def test_dst(spec, result):
 )
 def test_empty_target(spec, result):
     return run_test(config, spec, result)
+
+
+@pytest.mark.parametrize(
+    'metrics,expected_attrs',
+    (
+        ({'mtu': 1500}, [['RTAX_MTU', 1500]]),
+        ({'cc_algo': 'cubic'}, [['RTAX_CC_ALGO', 'cubic']]),
+        (
+            {'mtu': 1280, 'cc_algo': 'bbr'},
+            [['RTAX_MTU', 1280], ['RTAX_CC_ALGO', 'bbr']],
+        ),
+    ),
+    ids=['mtu-only', 'cc_algo-only', 'mtu-and-cc_algo'],
+)
+def test_metrics(metrics, expected_attrs):
+    spec = Request({'dst': '10.0.0.0/24', 'metrics': metrics})
+    result = Result(
+        {
+            'dst': '10.0.0.0',
+            'dst_len': 24,
+            'family': AF_INET,
+            'metrics': {'attrs': expected_attrs},
+        }
+    )
+    run_test(config, spec, result)


### PR DESCRIPTION
This PR adds support to read and write RTAX_CC_ALGO on route metrics.

I've expanded the unit tests, and integration tests to cover reading/writing this new metric, and also fixed a type annotation error flagged by `make format`

For reference here's the manpage for (rtnetlink)[https://man7.org/linux/man-pages/man7/rtnetlink.7.html] which shows that `RTAX_CC_ALGO` comes after `RTAX_QUICKACK`

Signed-off-by: rmanyari@hudson-trading.com