### PR TITLE
rtnl/ndmsg: add missing NTF flags

### DIFF
--- a/pyroute2/netlink/rtnl/ndmsg.py
+++ b/pyroute2/netlink/rtnl/ndmsg.py
@@ -7,6 +7,8 @@ NTF_SELF = 0x02
 NTF_MASTER = 0x04
 NTF_PROXY = 0x08
 NTF_EXT_LEARNED = 0x10
+NTF_OFFLOADED = 0x20
+NTF_STICKY = 0x40
 NTF_ROUTER = 0x80
 
 # neighbor cache entry states


### PR DESCRIPTION
This PR completes the list of available NTF flags.
I came across a situation in which I needed the `NFT_STICKY` flag for a bunch of static fdb entries and found the functionality missing.

See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/neighbour.h#n51