### PR TITLE
docs: fix clsact example interface variable

### DIFF
--- a/pyroute2/netlink/rtnl/tcmsg/sched_clsact.py
+++ b/pyroute2/netlink/rtnl/tcmsg/sched_clsact.py
@@ -13,8 +13,8 @@ BPF ingress/egress example using clsact qdisc::
 
     # open_bpf_fd is outside the scope of pyroute2
     #fd = open_bpf_fd()
-    eth0 = ip.get_links(ifname="eth0")[0]
-    ip.tc("add", "clsact", eth0)
+    idx = ip.get_links(ifname="eth0")[0]
+    ip.tc("add", "clsact", idx)
     # add ingress clsact
     ip.tc("add-filter", "bpf", idx, ":1", fd=fd, name="myprog",
           parent="ffff:fff2", classid=1, direct_action=True)


### PR DESCRIPTION
## Summary
- rename the clsact documentation example variable from `eth0` to `idx`
- use the same variable in the qdisc and filter examples so the snippet is internally consistent

Fixes #957

## Testing
- Not run; documentation-only comment change created through the GitHub API without cloning the repo locally.