### PR TITLE
fix(netlink): guard string.decode() against AttributeError in NLA array mode

### DIFF
--- a/pyroute2/netlink/__init__.py
+++ b/pyroute2/netlink/__init__.py
@@ -2355,10 +2355,11 @@ class nlmsg_atoms(object):
         def decode(self):
             nla_base_string.decode(self)
             self.value = self['value']
-            try:
-                self.value = self.value.decode('utf-8')
-            except UnicodeDecodeError:
-                pass  # Failed to decode, keep undecoded value
+            if isinstance(self.value, bytes):
+                try:
+                    self.value = self.value.decode('utf-8')
+                except UnicodeDecodeError:
+                    pass  # Failed to decode, keep undecoded value
 
     class asciiz(string):
         '''

--- a/tests/test_unit/test_nlmsg/test_string_nla_array.py
+++ b/tests/test_unit/test_nlmsg/test_string_nla_array.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression test for https://github.com/svinota/pyroute2/issues/1330
+#
+# NL80211_ATTR_SCAN_SSIDS is declared as *string (an NLA array of strings).
+# When the outer NLA is decoded with _nla_array=True, self.value is set to a
+# list of child cells by nla_base.decode(). The string.decode() method then
+# tried to call self.value.decode('utf-8') on that list, raising:
+#
+#     AttributeError: 'list' object has no attribute 'decode'
+#
+# The fix: guard the utf-8 decode with isinstance(self.value, bytes).
+
+import struct
+
+import pytest
+
+from pyroute2.netlink import nlmsg_atoms
+
+
+def _build_string_nla_array(*strings):
+    """Build a raw NLA payload for an array of strings.
+
+    The outer NLA header is prepended so the result can be passed directly
+    to nlmsg_atoms.string(data=...) for decoding.
+    """
+    payload = bytearray()
+    for i, s in enumerate(strings):
+        encoded = s.encode('utf-8') if s else b''
+        inner_length = 4 + len(encoded)  # 4-byte NLA header
+        payload += struct.pack('HH', inner_length, i)
+        payload += encoded
+        # Pad to 4-byte boundary
+        pad = (4 - (inner_length % 4)) % 4
+        payload += b'\x00' * pad
+
+    total_length = 4 + len(payload)
+    return bytearray(struct.pack('HH', total_length, 0)) + payload
+
+
+def test_string_nla_array_decode_no_attributeerror():
+    """string.decode() with _nla_array=True must not raise AttributeError."""
+    buf = _build_string_nla_array('', 'ssid_a', 'ssid_b')
+    instance = nlmsg_atoms.string(data=buf, offset=0)
+    instance._nla_array = True
+    instance.decode()  # must not raise
+
+
+def test_string_nla_array_value_is_list():
+    """After decoding a *string NLA, the value must be a list, not raw bytes."""
+    buf = _build_string_nla_array('', 'ssid_a')
+    instance = nlmsg_atoms.string(data=buf, offset=0)
+    instance._nla_array = True
+    instance.decode()
+    assert isinstance(
+        instance.value, list
+    ), f"Expected list, got {type(instance.value).__name__}"
+
+
+def test_string_nla_plain_decode_still_returns_str():
+    """Ensure the fix does not break plain (non-array) string decode."""
+    text = 'hello'
+    encoded = text.encode('utf-8')
+    length = 4 + len(encoded)
+    buf = bytearray(struct.pack('HH', length, 0)) + bytearray(encoded)
+    instance = nlmsg_atoms.string(data=buf, offset=0)
+    instance._nla_array = False
+    instance.decode()
+    assert instance.value == text, f"Expected {text!r}, got {instance.value!r}"

--- a/tests/test_unit/test_nlmsg/test_string_nla_array.py
+++ b/tests/test_unit/test_nlmsg/test_string_nla_array.py
@@ -13,8 +13,6 @@
 
 import struct
 
-import pytest
-
 from pyroute2.netlink import nlmsg_atoms
 
 
@@ -47,7 +45,7 @@ def test_string_nla_array_decode_no_attributeerror():
 
 
 def test_string_nla_array_value_is_list():
-    """After decoding a *string NLA, the value must be a list, not raw bytes."""
+    """After decoding a *string NLA, value must be a list, not raw bytes."""
     buf = _build_string_nla_array('', 'ssid_a')
     instance = nlmsg_atoms.string(data=buf, offset=0)
     instance._nla_array = True


### PR DESCRIPTION
## Problem

When an NLA attribute is declared as `*string` (an array of strings, e.g. `NL80211_ATTR_SCAN_SSIDS`), the base class `nla_base.decode()` sets `self.value` to a list of child cell objects rather than raw bytes. `nlmsg_atoms.string.decode()` then unconditionally called:

```python
self.value = self.value.decode('utf-8')
```

on that list, raising:

```
AttributeError: 'list' object has no attribute 'decode'
```

This produced a WARNING traceback logged on every `NL80211_CMD_TRIGGER_SCAN` event when debug logging was enabled. The attribute value was still parsed correctly after the first failed call (because `cell.decoded` was already set to `True` by the base class), so the error was non-fatal but noisy.

Repro from #1330:

```python
import logging
import pyroute2

logging.basicConfig(level=logging.DEBUG)
nl80211 = pyroute2.netlink.nl80211.NL80211()
nl80211.bind()
nl80211.add_membership("scan")
for event in nl80211.get():
    print(event)
```

Triggers:
```
WARNING:pyroute2.netlink:decoding NL80211_ATTR_SCAN_SSIDS
WARNING:pyroute2.netlink:AttributeError: 'list' object has no attribute 'decode'
```

## Fix

One-line guard: only call `.decode('utf-8')` when `self.value` is actually bytes. When `_nla_array=True`, the value is already a list of child cells and should be left as-is.

```python
if isinstance(self.value, bytes):
    try:
        self.value = self.value.decode('utf-8')
    except UnicodeDecodeError:
        pass
```

## Tests

Three unit tests added to `tests/test_unit/test_nlmsg/test_string_nla_array.py`:

- `test_string_nla_array_decode_no_attributeerror`: verifies decode does not raise
- `test_string_nla_array_value_is_list`: verifies the decoded value is a list
- `test_string_nla_plain_decode_still_returns_str`: verifies plain (non-array) string decode is unchanged

Run with:
```
make test session=unit
```

The tests pass on Linux. They cannot run on Windows due to `fcntl` being imported transitively through `pyroute2/__init__.py`, which is consistent with the rest of the `test_unit` suite.

Closes #1330.